### PR TITLE
Fix tasks without GitHub issue missing from daily log

### DIFF
--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -35,10 +35,15 @@ export async function getTasks(params?: {
   return res.data;
 }
 
+export async function getTask(id: string): Promise<Task> {
+  const res = await client.get<Task>(`/tasks/${id}`);
+  return res.data;
+}
+
 /** Active tasks = status is not 'done' and is_active=true for the current user. */
 export async function getActiveTasks(): Promise<Task[]> {
-  const res = await client.get<Task[]>('/tasks', { params: { active: true } });
-  return res.data;
+  const res = await client.get<Task[]>('/tasks', { params: { is_active: true } });
+  return res.data.filter((t) => t.status !== 'done');
 }
 
 export async function createTask(payload: CreateTaskPayload): Promise<Task> {
@@ -50,7 +55,7 @@ export async function updateTask(
   id: string,
   payload: UpdateTaskPayload
 ): Promise<Task> {
-  const res = await client.patch<Task>(`/tasks/${id}`, payload);
+  const res = await client.put<Task>(`/tasks/${id}`, payload);
   return res.data;
 }
 

--- a/frontend/src/components/tasks/WorkLogRow.tsx
+++ b/frontend/src/components/tasks/WorkLogRow.tsx
@@ -1,9 +1,10 @@
-import { useState } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { updateTask } from '../../api/tasks';
 import type {
   DailyWorkLogFormEntry,
   SelfAssessmentTag,
   BlockerType,
+  Task,
 } from '../../types/dailyRecord';
 
 interface WorkLogRowProps {
@@ -17,8 +18,10 @@ interface WorkLogRowProps {
   onRemove: (index: number) => void;
   onMoveUp: (index: number) => void;
   onMoveDown: (index: number) => void;
-  /** Called after task status is updated to 'done' so parent can remove the row */
-  onTaskDone: (index: number) => void;
+  /** Called after task fields (status/title/description) are updated via API */
+  onTaskUpdated: (index: number, updated: Task) => void;
+  /** Optional left-border accent color for category color-grouping */
+  accentColor?: string;
 }
 
 export const WorkLogRow = ({
@@ -32,13 +35,31 @@ export const WorkLogRow = ({
   onRemove,
   onMoveUp,
   onMoveDown,
-  onTaskDone,
+  onTaskUpdated,
+  accentColor,
 }: WorkLogRowProps) => {
   const [showBlocker, setShowBlocker] = useState(
     log.task.status === 'blocked' || !!log.blocker_type_id
   );
-  const [markingDone, setMarkingDone] = useState(false);
-  const [doneError, setDoneError] = useState<string | null>(null);
+  const [statusUpdating, setStatusUpdating] = useState(false);
+  const [updateError, setUpdateError] = useState<string | null>(null);
+
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(log.task.title);
+  const titleInputRef = useRef<HTMLInputElement>(null);
+
+  const [showDesc, setShowDesc] = useState(!!log.task.description);
+  const [descDraft, setDescDraft] = useState(log.task.description ?? '');
+
+  // Keep drafts in sync when parent updates the task object
+  useEffect(() => {
+    if (!editingTitle) setTitleDraft(log.task.title);
+  }, [log.task.title, editingTitle]);
+
+  useEffect(() => {
+    setDescDraft(log.task.description ?? '');
+    if (log.task.description) setShowDesc(true);
+  }, [log.task.description]);
 
   const handleTagToggle = (tagId: string) => {
     const existing = log.self_assessment_tags.find(
@@ -76,19 +97,48 @@ export const WorkLogRow = ({
     });
   };
 
-  const handleMarkDone = async () => {
-    if (!window.confirm(`Mark "${log.task.title}" as done? This cannot be undone from this form.`)) {
+  const handleStatusChange = async (newStatus: Task['status']) => {
+    setStatusUpdating(true);
+    setUpdateError(null);
+    try {
+      const updated = await updateTask(log.task.id, { status: newStatus });
+      onTaskUpdated(index, updated);
+    } catch {
+      setUpdateError('Failed to update task status.');
+    } finally {
+      setStatusUpdating(false);
+    }
+  };
+
+  const handleTitleSave = async () => {
+    const trimmed = titleDraft.trim();
+    if (!trimmed || trimmed === log.task.title) {
+      setEditingTitle(false);
+      setTitleDraft(log.task.title);
       return;
     }
-    setMarkingDone(true);
-    setDoneError(null);
+    setUpdateError(null);
     try {
-      await updateTask(log.task.id, { status: 'done' });
-      onTaskDone(index);
+      const updated = await updateTask(log.task.id, { title: trimmed });
+      onTaskUpdated(index, updated);
     } catch {
-      setDoneError('Failed to mark task as done.');
-    } finally {
-      setMarkingDone(false);
+      setUpdateError('Failed to update task title.');
+      setTitleDraft(log.task.title);
+    }
+    setEditingTitle(false);
+  };
+
+  const handleDescSave = async () => {
+    const trimmed = descDraft.trim();
+    const currentDesc = log.task.description ?? '';
+    if (trimmed === currentDesc) return;
+    setUpdateError(null);
+    try {
+      const updated = await updateTask(log.task.id, { description: trimmed || null });
+      onTaskUpdated(index, updated);
+    } catch {
+      setUpdateError('Failed to update task description.');
+      setDescDraft(currentDesc);
     }
   };
 
@@ -102,18 +152,62 @@ export const WorkLogRow = ({
   const s = rowStyles;
 
   return (
-    <div style={s.card}>
+    <div style={{ ...s.card, ...(accentColor ? { borderLeft: `4px solid ${accentColor}` } : {}) }}>
       {/* Header: task name + status + actions */}
       <div style={s.header}>
         <div style={s.taskMeta}>
-          <span
+          <select
+            value={log.task.status}
+            onChange={(e) => handleStatusChange(e.target.value as Task['status'])}
+            disabled={!isEditable || statusUpdating}
             style={{
+<<<<<<< HEAD
               ...s.statusDot,
               background: statusColor[log.task.status] ?? 'var(--text-muted)',
+=======
+              ...s.statusSelect,
+              borderColor: statusColor[log.task.status] ?? '#a0aec0',
+              color: statusColor[log.task.status] ?? '#a0aec0',
+>>>>>>> 490d516 (fix(daily-form): show tasks without GitHub issue in daily work log)
             }}
-            title={`Status: ${log.task.status}`}
-          />
-          <span style={s.taskTitle}>{log.task.title}</span>
+            title="Task status"
+          >
+            <option value="todo">todo</option>
+            <option value="running">running</option>
+            <option value="done">done</option>
+            <option value="blocked">blocked</option>
+          </select>
+          {editingTitle ? (
+            <input
+              ref={titleInputRef}
+              type="text"
+              value={titleDraft}
+              onChange={(e) => setTitleDraft(e.target.value)}
+              onBlur={handleTitleSave}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') { e.preventDefault(); titleInputRef.current?.blur(); }
+                if (e.key === 'Escape') { setEditingTitle(false); setTitleDraft(log.task.title); }
+              }}
+              style={s.titleInput}
+              autoFocus
+            />
+          ) : (
+            <>
+              <span style={s.taskTitle} title={log.task.title}>
+                {log.task.title}
+              </span>
+              {isEditable && (
+                <button
+                  type="button"
+                  onClick={() => setEditingTitle(true)}
+                  style={s.editTitleBtn}
+                  title="Edit title"
+                >
+                  ✏
+                </button>
+              )}
+            </>
+          )}
           {log.task.github_issue_url && (
             <a
               href={log.task.github_issue_url}
@@ -199,41 +293,81 @@ export const WorkLogRow = ({
             );
             const selected = !!ref;
             const isPrimary = ref?.is_primary ?? false;
-            return (
-              <span key={tag.id} style={s.tagWrapper}>
+
+            // When read-only, only render selected tags
+            if (!isEditable && !selected) return null;
+
+            if (isPrimary) {
+              // Primary: solid filled highlight
+              return (
                 <button
+                  key={tag.id}
                   type="button"
-                  onClick={() => handleTagToggle(tag.id)}
+                  onClick={() => isEditable && handleTagToggle(tag.id)}
                   disabled={!isEditable}
                   style={{
+<<<<<<< HEAD
                     ...s.tagBtn,
                     background: selected ? 'var(--primary)' : 'var(--border)',
                     color: selected ? '#fff' : 'var(--text-body)',
                     opacity: !isEditable ? 0.6 : 1,
                     cursor: !isEditable ? 'default' : 'pointer',
+=======
+                    ...s.tagChip,
+                    background: '#3182ce',
+                    color: '#fff',
+                    border: '1px solid #3182ce',
+                    cursor: isEditable ? 'pointer' : 'default',
+>>>>>>> 490d516 (fix(daily-form): show tasks without GitHub issue in daily work log)
                   }}
+                  title="Primary tag — click to deselect"
                 >
-                  {tag.name}
+                  ★ {tag.name}
                 </button>
-                {selected && !isPrimary && (
-                  <button
-                    type="button"
-                    onClick={() => handleSetPrimary(tag.id)}
-                    disabled={!isEditable}
-                    style={{
-                      ...s.primaryBtn,
-                      opacity: !isEditable ? 0.4 : 1,
-                      cursor: !isEditable ? 'default' : 'pointer',
-                    }}
-                    title="Set as primary"
-                  >
-                    ★
-                  </button>
-                )}
-                {selected && isPrimary && (
-                  <span style={s.primaryIndicator} title="Primary tag">★</span>
-                )}
-              </span>
+              );
+            }
+
+            if (selected) {
+              // Selected non-primary: outline/wireframe, star inside to promote
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => isEditable && handleSetPrimary(tag.id)}
+                  onContextMenu={(e) => { e.preventDefault(); if (isEditable) handleTagToggle(tag.id); }}
+                  disabled={!isEditable}
+                  style={{
+                    ...s.tagChip,
+                    background: 'transparent',
+                    color: '#3182ce',
+                    border: '1px solid #3182ce',
+                    cursor: isEditable ? 'pointer' : 'default',
+                  }}
+                  title={isEditable ? 'Click to set as primary · right-click to deselect' : tag.name}
+                >
+                  ☆ {tag.name}
+                </button>
+              );
+            }
+
+            // Unselected: gray chip
+            return (
+              <button
+                key={tag.id}
+                type="button"
+                onClick={() => handleTagToggle(tag.id)}
+                disabled={!isEditable}
+                style={{
+                  ...s.tagChip,
+                  background: '#e2e8f0',
+                  color: '#718096',
+                  border: '1px solid #e2e8f0',
+                  cursor: 'pointer',
+                }}
+                title="Click to select"
+              >
+                {tag.name}
+              </button>
             );
           })}
         </div>
@@ -299,20 +433,44 @@ export const WorkLogRow = ({
         </div>
       )}
 
-      {/* Mark done */}
-      {isEditable && log.task.status !== 'done' && (
-        <div style={{ marginTop: '0.5rem' }}>
-          <button
-            type="button"
-            onClick={handleMarkDone}
-            disabled={markingDone}
-            style={s.doneBtn}
-          >
-            {markingDone ? 'Marking…' : '✓ Mark task done'}
-          </button>
-          {doneError && <span style={s.doneError}>{doneError}</span>}
+      {/* Description (collapsible) */}
+      {!showDesc && isEditable && (
+        <button
+          type="button"
+          onClick={() => setShowDesc(true)}
+          style={s.blockerToggle}
+        >
+          + Edit description
+        </button>
+      )}
+      {showDesc && (
+        <div style={s.descSection}>
+          <div style={{ ...s.fieldRow, alignItems: 'flex-start' }}>
+            <label style={s.label}>Description</label>
+            <textarea
+              value={descDraft}
+              onChange={(e) => setDescDraft(e.target.value)}
+              onBlur={handleDescSave}
+              rows={2}
+              style={{ ...s.input, resize: 'vertical' }}
+              disabled={!isEditable}
+              placeholder="Task description"
+            />
+            {isEditable && (
+              <button
+                type="button"
+                onClick={() => { setShowDesc(false); setDescDraft(log.task.description ?? ''); }}
+                style={{ ...s.iconBtn, alignSelf: 'flex-start' }}
+              >
+                ✕
+              </button>
+            )}
+          </div>
         </div>
       )}
+
+      {/* Inline update error */}
+      {updateError && <p style={s.updateError}>{updateError}</p>}
     </div>
   );
 };
@@ -332,10 +490,34 @@ const rowStyles: Record<string, React.CSSProperties> = {
     marginBottom: '0.75rem',
   },
   taskMeta: { display: 'flex', alignItems: 'center', gap: '0.5rem', flex: 1, minWidth: 0 },
-  statusDot: {
-    width: '10px',
-    height: '10px',
-    borderRadius: '50%',
+  statusSelect: {
+    padding: '0.15rem 0.35rem',
+    border: '1px solid',
+    borderRadius: '4px',
+    fontSize: '0.78rem',
+    fontWeight: 600,
+    background: '#fff',
+    cursor: 'pointer',
+    flexShrink: 0,
+  },
+  titleInput: {
+    fontWeight: 600,
+    fontSize: '0.95rem',
+    border: '1px solid #3182ce',
+    borderRadius: '4px',
+    padding: '0.1rem 0.35rem',
+    flex: 1,
+    minWidth: '100px',
+    outline: 'none',
+  },
+  editTitleBtn: {
+    background: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    fontSize: '0.8rem',
+    color: '#a0aec0',
+    padding: '0 0.1rem',
+    lineHeight: 1,
     flexShrink: 0,
   },
   taskTitle: {
@@ -392,14 +574,14 @@ const rowStyles: Record<string, React.CSSProperties> = {
   },
   effortHint: { fontSize: '0.78rem', color: 'var(--text-secondary)' },
   tagGroup: { display: 'flex', flexWrap: 'wrap', gap: '0.35rem' },
-  tagWrapper: { display: 'inline-flex', alignItems: 'center' },
-  tagBtn: {
-    padding: '0.2rem 0.55rem',
-    border: 'none',
-    borderRadius: '4px',
+  tagChip: {
+    padding: '0.2rem 0.6rem',
+    borderRadius: '999px',
     fontSize: '0.8rem',
     fontWeight: 500,
+    transition: 'opacity 0.1s',
   },
+<<<<<<< HEAD
   primaryBtn: {
     background: 'none',
     border: 'none',
@@ -410,6 +592,9 @@ const rowStyles: Record<string, React.CSSProperties> = {
   },
   primaryIndicator: { color: 'var(--warning)', fontSize: '0.9rem', padding: '0 0.15rem' },
   tagError: { color: 'var(--error)', fontSize: '0.75rem', margin: '-0.1rem 0 0.5rem' },
+=======
+  tagError: { color: '#e53e3e', fontSize: '0.75rem', margin: '-0.1rem 0 0.5rem' },
+>>>>>>> 490d516 (fix(daily-form): show tasks without GitHub issue in daily work log)
   blockerSection: {
     background: 'var(--error-bg)',
     border: '1px solid var(--error-bg)',
@@ -426,6 +611,7 @@ const rowStyles: Record<string, React.CSSProperties> = {
     padding: '0.1rem 0',
     marginBottom: '0.4rem',
   },
+<<<<<<< HEAD
   privateLabel: { color: 'var(--text-muted)', fontWeight: 400, fontSize: '0.75rem' },
   doneBtn: {
     padding: '0.25rem 0.7rem',
@@ -438,4 +624,15 @@ const rowStyles: Record<string, React.CSSProperties> = {
     fontWeight: 500,
   },
   doneError: { color: 'var(--error)', fontSize: '0.8rem', marginLeft: '0.5rem' },
+=======
+  privateLabel: { color: '#a0aec0', fontWeight: 400, fontSize: '0.75rem' },
+  descSection: {
+    background: '#f0f4f8',
+    border: '1px solid #e2e8f0',
+    borderRadius: '6px',
+    padding: '0.6rem',
+    marginBottom: '0.5rem',
+  },
+  updateError: { color: '#e53e3e', fontSize: '0.78rem', margin: '0.25rem 0 0' },
+>>>>>>> 490d516 (fix(daily-form): show tasks without GitHub issue in daily work log)
 };

--- a/frontend/src/components/tasks/WorkLogRow.tsx
+++ b/frontend/src/components/tasks/WorkLogRow.tsx
@@ -161,14 +161,9 @@ export const WorkLogRow = ({
             onChange={(e) => handleStatusChange(e.target.value as Task['status'])}
             disabled={!isEditable || statusUpdating}
             style={{
-<<<<<<< HEAD
-              ...s.statusDot,
-              background: statusColor[log.task.status] ?? 'var(--text-muted)',
-=======
               ...s.statusSelect,
-              borderColor: statusColor[log.task.status] ?? '#a0aec0',
-              color: statusColor[log.task.status] ?? '#a0aec0',
->>>>>>> 490d516 (fix(daily-form): show tasks without GitHub issue in daily work log)
+              borderColor: statusColor[log.task.status] ?? 'var(--text-muted)',
+              color: statusColor[log.task.status] ?? 'var(--text-muted)',
             }}
             title="Task status"
           >
@@ -306,19 +301,11 @@ export const WorkLogRow = ({
                   onClick={() => isEditable && handleTagToggle(tag.id)}
                   disabled={!isEditable}
                   style={{
-<<<<<<< HEAD
-                    ...s.tagBtn,
-                    background: selected ? 'var(--primary)' : 'var(--border)',
-                    color: selected ? '#fff' : 'var(--text-body)',
-                    opacity: !isEditable ? 0.6 : 1,
-                    cursor: !isEditable ? 'default' : 'pointer',
-=======
                     ...s.tagChip,
-                    background: '#3182ce',
+                    background: 'var(--primary)',
                     color: '#fff',
-                    border: '1px solid #3182ce',
+                    border: '1px solid var(--primary)',
                     cursor: isEditable ? 'pointer' : 'default',
->>>>>>> 490d516 (fix(daily-form): show tasks without GitHub issue in daily work log)
                   }}
                   title="Primary tag — click to deselect"
                 >
@@ -339,8 +326,8 @@ export const WorkLogRow = ({
                   style={{
                     ...s.tagChip,
                     background: 'transparent',
-                    color: '#3182ce',
-                    border: '1px solid #3182ce',
+                    color: 'var(--primary)',
+                    border: '1px solid var(--primary)',
                     cursor: isEditable ? 'pointer' : 'default',
                   }}
                   title={isEditable ? 'Click to set as primary · right-click to deselect' : tag.name}
@@ -359,9 +346,9 @@ export const WorkLogRow = ({
                 disabled={!isEditable}
                 style={{
                   ...s.tagChip,
-                  background: '#e2e8f0',
-                  color: '#718096',
-                  border: '1px solid #e2e8f0',
+                  background: 'var(--border-subtle)',
+                  color: 'var(--text-secondary)',
+                  border: '1px solid var(--border-subtle)',
                   cursor: 'pointer',
                 }}
                 title="Click to select"
@@ -496,14 +483,14 @@ const rowStyles: Record<string, React.CSSProperties> = {
     borderRadius: '4px',
     fontSize: '0.78rem',
     fontWeight: 600,
-    background: '#fff',
+    background: 'var(--bg)',
     cursor: 'pointer',
     flexShrink: 0,
   },
   titleInput: {
     fontWeight: 600,
     fontSize: '0.95rem',
-    border: '1px solid #3182ce',
+    border: '1px solid var(--primary)',
     borderRadius: '4px',
     padding: '0.1rem 0.35rem',
     flex: 1,
@@ -515,7 +502,7 @@ const rowStyles: Record<string, React.CSSProperties> = {
     border: 'none',
     cursor: 'pointer',
     fontSize: '0.8rem',
-    color: '#a0aec0',
+    color: 'var(--text-muted)',
     padding: '0 0.1rem',
     lineHeight: 1,
     flexShrink: 0,
@@ -581,20 +568,7 @@ const rowStyles: Record<string, React.CSSProperties> = {
     fontWeight: 500,
     transition: 'opacity 0.1s',
   },
-<<<<<<< HEAD
-  primaryBtn: {
-    background: 'none',
-    border: 'none',
-    cursor: 'pointer',
-    color: 'var(--warning)',
-    fontSize: '0.9rem',
-    padding: '0 0.15rem',
-  },
-  primaryIndicator: { color: 'var(--warning)', fontSize: '0.9rem', padding: '0 0.15rem' },
   tagError: { color: 'var(--error)', fontSize: '0.75rem', margin: '-0.1rem 0 0.5rem' },
-=======
-  tagError: { color: '#e53e3e', fontSize: '0.75rem', margin: '-0.1rem 0 0.5rem' },
->>>>>>> 490d516 (fix(daily-form): show tasks without GitHub issue in daily work log)
   blockerSection: {
     background: 'var(--error-bg)',
     border: '1px solid var(--error-bg)',
@@ -611,28 +585,13 @@ const rowStyles: Record<string, React.CSSProperties> = {
     padding: '0.1rem 0',
     marginBottom: '0.4rem',
   },
-<<<<<<< HEAD
   privateLabel: { color: 'var(--text-muted)', fontWeight: 400, fontSize: '0.75rem' },
-  doneBtn: {
-    padding: '0.25rem 0.7rem',
-    background: 'var(--success)',
-    color: '#fff',
-    border: 'none',
-    borderRadius: '4px',
-    cursor: 'pointer',
-    fontSize: '0.8rem',
-    fontWeight: 500,
-  },
-  doneError: { color: 'var(--error)', fontSize: '0.8rem', marginLeft: '0.5rem' },
-=======
-  privateLabel: { color: '#a0aec0', fontWeight: 400, fontSize: '0.75rem' },
   descSection: {
-    background: '#f0f4f8',
-    border: '1px solid #e2e8f0',
+    background: 'var(--bg-tertiary)',
+    border: '1px solid var(--border-subtle)',
     borderRadius: '6px',
     padding: '0.6rem',
     marginBottom: '0.5rem',
   },
-  updateError: { color: '#e53e3e', fontSize: '0.78rem', margin: '0.25rem 0 0' },
->>>>>>> 490d516 (fix(daily-form): show tasks without GitHub issue in daily work log)
+  updateError: { color: 'var(--error)', fontSize: '0.78rem', margin: '0.25rem 0 0' },
 };

--- a/frontend/src/pages/DailyFormPage.tsx
+++ b/frontend/src/pages/DailyFormPage.tsx
@@ -70,7 +70,7 @@ const CATEGORY_PALETTE = [
   '#f6ad55', // amber
   '#667eea', // indigo
 ];
-const CATEGORY_FALLBACK_COLOR = '#a0aec0'; // gray — for unknown category
+const CATEGORY_FALLBACK_COLOR = 'var(--text-muted)'; // gray — for unknown category
 
 function getColorMap(categories: Category[]): Map<string, string> {
   const map = new Map<string, string>();
@@ -626,7 +626,7 @@ export const DailyFormPage = () => {
                       background: color,
                       flexShrink: 0,
                     }} />
-                    <span style={{ fontWeight: 600, fontSize: '0.85rem', color: '#4a5568' }}>
+                    <span style={{ fontWeight: 600, fontSize: '0.85rem', color: 'var(--text-body)' }}>
                       {catName}
                     </span>
                   </div>
@@ -736,7 +736,7 @@ export const DailyFormPage = () => {
         <div style={s.modalOverlay}>
           <div style={s.modalBox}>
             <h3 style={{ margin: '0 0 0.75rem', fontSize: '1rem' }}>Confirm Check</h3>
-            <p style={{ margin: '0 0 1.25rem', color: '#4a5568', fontSize: '0.9rem' }}>
+            <p style={{ margin: '0 0 1.25rem', color: 'var(--text-body)', fontSize: '0.9rem' }}>
               Submit today’s record? The form will be locked until you click Re-edit.
             </p>
             <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
@@ -928,7 +928,7 @@ const styles: Record<string, React.CSSProperties> = {
     zIndex: 1000,
   },
   modalBox: {
-    background: '#fff',
+    background: 'var(--bg)',
     borderRadius: '10px',
     padding: '1.5rem',
     width: '360px',

--- a/frontend/src/pages/DailyFormPage.tsx
+++ b/frontend/src/pages/DailyFormPage.tsx
@@ -9,7 +9,7 @@ import {
   getAbsences,
   getUnlockGrants,
 } from '../api/dailyRecords';
-import { getActiveTasks } from '../api/tasks';
+import { getActiveTasks, getTask } from '../api/tasks';
 import { getCategories, getSelfAssessmentTags, getBlockerTypes } from '../api/categories';
 import { getProjects } from '../api/projects';
 import { WorkLogRow } from '../components/tasks/WorkLogRow';
@@ -55,6 +55,29 @@ function computeEditDeadlineJST(recordDate: string): Date {
       saturdayLocal.getDate(),
     ) - 9 * 60 * 60 * 1000
   );
+}
+
+// ---------------------------------------------------------------------------
+// Category color palette (cycles for large category lists)
+// ---------------------------------------------------------------------------
+const CATEGORY_PALETTE = [
+  '#4299e1', // blue
+  '#48bb78', // green
+  '#ed8936', // orange
+  '#9f7aea', // purple
+  '#e53e3e', // red
+  '#38b2ac', // teal
+  '#f6ad55', // amber
+  '#667eea', // indigo
+];
+const CATEGORY_FALLBACK_COLOR = '#a0aec0'; // gray — for unknown category
+
+function getColorMap(categories: Category[]): Map<string, string> {
+  const map = new Map<string, string>();
+  categories.forEach((cat, i) => {
+    map.set(cat.id, CATEGORY_PALETTE[i % CATEGORY_PALETTE.length]);
+  });
+  return map;
 }
 
 function getEditWindowState(
@@ -138,6 +161,8 @@ export const DailyFormPage = () => {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
+  const [checked, setChecked] = useState(false);
+  const [showConfirmCheck, setShowConfirmCheck] = useState(false);
 
   // Task create modal
   const [showTaskModal, setShowTaskModal] = useState(false);
@@ -147,7 +172,10 @@ export const DailyFormPage = () => {
     () => getEditWindowState(recordDate, formOpenedAt.current),
     [recordDate]
   );
-  const isEditable = windowState !== 'locked' || !!unlockGrant;
+  const isEditable = (windowState !== 'locked' || !!unlockGrant) && !checked;
+
+  // Category → accent color map (stable across renders, cycles through palette)
+  const categoryColorMap = useMemo(() => getColorMap(categories), [categories]);
 
   // Load reference data + existing record
   useEffect(() => {
@@ -163,17 +191,21 @@ export const DailyFormPage = () => {
     setDayLoad(3);
     setDayNote('');
     setSuccessMsg(null);
-    Promise.all([
-      getCategories(),
-      getSelfAssessmentTags(),
-      getBlockerTypes(),
-      getProjects(),
-      getDailyRecords({ date: recordDate }),
-      getAbsences({ start_date: recordDate, end_date: recordDate }),
-      getUnlockGrants({ record_date: recordDate }),
-      getActiveTasks(),
-    ])
-      .then(([cats, tagList, btList, projs, records, absences, grants, activeTasks]) => {
+    setChecked(false);
+    setShowConfirmCheck(false);
+    (async () => {
+      try {
+        const [cats, tagList, btList, projs, records, absences, grants, activeTasks] =
+          await Promise.all([
+            getCategories(),
+            getSelfAssessmentTags(),
+            getBlockerTypes(),
+            getProjects(),
+            getDailyRecords({ date: recordDate }),
+            getAbsences({ start_date: recordDate, end_date: recordDate }),
+            getUnlockGrants({ record_date: recordDate }),
+            getActiveTasks(),
+          ]);
         setCategories(cats);
         setTags(tagList);
         setBlockerTypes(btList);
@@ -182,30 +214,53 @@ export const DailyFormPage = () => {
         if (records.length > 0) {
           const rec = records[0];
           setExistingRecord(rec);
+          setChecked(true); // already submitted — start in locked state
           setDayLoad(rec.day_load ?? 3);
           setDayNote(rec.day_note ?? '');
 
-          const logsByTaskId = new Map(
-            rec.daily_work_logs.map((l) => [l.task_id, l])
-          );
-          const rows: DailyWorkLogFormEntry[] = activeTasks.map((task) => {
-            const existing = logsByTaskId.get(task.id);
-            if (existing) {
-              return {
+          const activeTasksById = new Map(activeTasks.map((t) => [t.id, t]));
+
+          // Fetch tasks that are in the saved record but no longer in activeTasks
+          // (e.g. soft-deleted tasks with is_active=false).
+          const orphanedIds = rec.daily_work_logs
+            .map((l) => l.task_id)
+            .filter((id) => !activeTasksById.has(id));
+          const orphanedTasks = (
+            await Promise.all(
+              orphanedIds.map((id) => getTask(id).catch(() => null))
+            )
+          ).filter((t): t is Task => t !== null);
+          const orphanedTasksById = new Map(orphanedTasks.map((t) => [t.id, t]));
+
+          const allTasksById = new Map([...activeTasksById, ...orphanedTasksById]);
+
+          // Part A: rows from saved logs (in sort_order), including orphaned tasks.
+          const savedLogRows: DailyWorkLogFormEntry[] = rec.daily_work_logs
+            .slice()
+            .sort((a, b) => a.sort_order - b.sort_order)
+            .flatMap((log) => {
+              const task = allTasksById.get(log.task_id);
+              if (!task) return []; // task no longer fetchable — skip gracefully
+              return [{
                 _key: newKey(),
                 task,
-                task_id: existing.task_id,
-                effort: existing.effort,
-                work_note: existing.work_note,
-                blocker_type_id: existing.blocker_type_id,
-                blocker_text: existing.blocker_text,
-                sort_order: existing.sort_order,
-                self_assessment_tags: existing.self_assessment_tags,
-              };
-            }
-            return taskToBlankLog(task);
-          });
-          setWorkLogs(rows);
+                task_id: log.task_id,
+                effort: log.effort,
+                work_note: log.work_note,
+                blocker_type_id: log.blocker_type_id,
+                blocker_text: log.blocker_text,
+                sort_order: log.sort_order,
+                self_assessment_tags: log.self_assessment_tags,
+              }];
+            });
+
+          // Part B: active tasks not already in the saved record — append as blank rows.
+          const loggedTaskIds = new Set(rec.daily_work_logs.map((l) => l.task_id));
+          const newBlankRows = activeTasks
+            .filter((t) => !loggedTaskIds.has(t.id))
+            .map(taskToBlankLog);
+
+          setWorkLogs([...savedLogRows, ...newBlankRows]);
         } else {
           setWorkLogs(activeTasks.map(taskToBlankLog));
         }
@@ -218,9 +273,12 @@ export const DailyFormPage = () => {
 
         const activeGrant = grants.find((g) => g.revoked_at === null);
         setUnlockGrant(activeGrant ?? null);
-      })
-      .catch(() => setError('Failed to load form data.'))
-      .finally(() => setLoading(false));
+      } catch {
+        setError('Failed to load form data.');
+      } finally {
+        setLoading(false);
+      }
+    })();
   }, [recordDate]);
 
   // Work log manipulation
@@ -244,13 +302,59 @@ export const DailyFormPage = () => {
     });
   }, []);
 
-  const handleTaskDone = useCallback((index: number) => {
-    setWorkLogs((prev) => prev.filter((_, i) => i !== index));
-  }, []);
+  // Silently persist the DailyRecord after a task mutation.
+  // Accepts an explicit snapshot so callers pass the already-updated logs
+  // rather than racing against the async state update.
+  // Gated on validatePrimaryTags — silently skips if tags are incomplete.
+  const autoSaveRecord = useCallback(async (logsSnapshot: DailyWorkLogFormEntry[]) => {
+    if (!isEditable || saving) return;
+    if (validatePrimaryTags(logsSnapshot) !== null) return;
+    const payload = {
+      day_load: dayLoad,
+      day_note: dayNote || null,
+      form_opened_at: formOpenedAt.current.toISOString(),
+      daily_work_logs: logsSnapshot.map((l, i) => ({
+        task_id: l.task_id,
+        effort: l.effort,
+        work_note: l.work_note,
+        blocker_type_id: l.blocker_type_id,
+        blocker_text: l.blocker_text,
+        sort_order: i,
+        self_assessment_tags: l.self_assessment_tags,
+      })),
+    };
+    try {
+      if (existingRecord) {
+        await updateDailyRecord(existingRecord.id, payload);
+      } else {
+        const created = await createDailyRecord({
+          record_date: recordDate,
+          ...payload,
+        });
+        setExistingRecord(created);
+      }
+    } catch (e) {
+      console.warn('[autoSave] DailyRecord auto-save failed:', e);
+    }
+  }, [isEditable, saving, dayLoad, dayNote, existingRecord, recordDate]);
 
   const handleTaskCreated = useCallback((task: Task) => {
-    setWorkLogs((prev) => [...prev, taskToBlankLog(task)]);
-  }, []);
+    const next = [...workLogs, taskToBlankLog(task)];
+    setWorkLogs(next);
+    // Silently skipped: new row has no tags yet, validatePrimaryTags will fail
+    void autoSaveRecord(next);
+  }, [workLogs, autoSaveRecord]);
+
+  const handleTaskUpdated = useCallback(
+    (index: number, updated: Task) => {
+      const next = workLogs.map((l, i) =>
+        i === index ? { ...l, task: updated, task_id: updated.id } : l
+      );
+      setWorkLogs(next);
+      void autoSaveRecord(next);
+    },
+    [workLogs, autoSaveRecord]
+  );
 
   // Toggle absence mode
   const toggleAbsence = async () => {
@@ -309,6 +413,14 @@ export const DailyFormPage = () => {
       return;
     }
 
+    // Show confirmation modal before saving
+    setShowConfirmCheck(true);
+  };
+
+  const confirmCheck = async () => {
+    setShowConfirmCheck(false);
+    if (!isEditable) return;
+
     setSaving(true);
     setError(null);
     setSuccessMsg(null);
@@ -331,15 +443,15 @@ export const DailyFormPage = () => {
     try {
       if (existingRecord) {
         await updateDailyRecord(existingRecord.id, payload);
-        setSuccessMsg('Record updated.');
       } else {
         const created = await createDailyRecord({
           record_date: recordDate,
           ...payload,
         });
         setExistingRecord(created);
-        setSuccessMsg('Record saved.');
       }
+      setSuccessMsg('Record checked.');
+      setChecked(true);
     } catch (err: unknown) {
       const msg =
         (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ??
@@ -372,11 +484,15 @@ export const DailyFormPage = () => {
         <button type="button" onClick={() => goToDate(-1)} style={s.navBtn}>
           ◀
         </button>
-        <h2 style={s.dateTitle}>{recordDate}</h2>
+        <input
+          type="date"
+          value={recordDate}
+          onChange={(e) => { if (e.target.value) navigate(`/daily/${e.target.value}`); }}
+          style={s.datePicker}
+        />
         <button
           type="button"
           onClick={() => goToDate(1)}
-          disabled={recordDate >= todayISO}
           style={s.navBtn}
         >
           ▶
@@ -475,32 +591,69 @@ export const DailyFormPage = () => {
             </p>
           )}
 
-          {workLogs.map((log, index) => (
-            <WorkLogRow
-              key={log._key}
-              log={log}
-              index={index}
-              totalLogs={workLogs.length}
-              tags={tags}
-              blockerTypes={blockerTypes}
-              isEditable={isEditable}
-              onChange={updateLog}
-              onRemove={removeLog}
-              onMoveUp={(i) => moveLog(i, 'up')}
-              onMoveDown={(i) => moveLog(i, 'down')}
-              onTaskDone={handleTaskDone}
-            />
-          ))}
-
-          <TaskCreateModal
-            open={showTaskModal}
-            onClose={() => setShowTaskModal(false)}
-            onCreated={handleTaskCreated}
-            categories={categories}
-            projects={projects}
-            blockerTypes={blockerTypes}
-            onProjectCreated={(project) => setProjects((prev) => [...prev, project])}
-          />
+          {(() => {
+            // Build ordered list of distinct category IDs (first-seen order)
+            const seenCatIds: string[] = [];
+            for (const log of workLogs) {
+              const catId = log.task.category_id ?? '__unknown__';
+              if (!seenCatIds.includes(catId)) seenCatIds.push(catId);
+            }
+            return seenCatIds.map((catId) => {
+              const group = workLogs.filter(
+                (l) => (l.task.category_id ?? '__unknown__') === catId
+              );
+              const catName =
+                catId === '__unknown__'
+                  ? 'Other'
+                  : (categories.find((c) => c.id === catId)?.name ?? 'Other');
+              const color =
+                catId === '__unknown__'
+                  ? CATEGORY_FALLBACK_COLOR
+                  : (categoryColorMap.get(catId) ?? CATEGORY_FALLBACK_COLOR);
+              return (
+                <div key={catId}>
+                  {/* Category group header */}
+                  <div style={{
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: '0.5rem',
+                    margin: '1rem 0 0.4rem',
+                  }}>
+                    <span style={{
+                      width: '12px',
+                      height: '12px',
+                      borderRadius: '3px',
+                      background: color,
+                      flexShrink: 0,
+                    }} />
+                    <span style={{ fontWeight: 600, fontSize: '0.85rem', color: '#4a5568' }}>
+                      {catName}
+                    </span>
+                  </div>
+                  {group.map((log) => {
+                    const index = workLogs.indexOf(log);
+                    return (
+                      <WorkLogRow
+                        key={log._key}
+                        log={log}
+                        index={index}
+                        totalLogs={workLogs.length}
+                        tags={tags}
+                        blockerTypes={blockerTypes}
+                        isEditable={isEditable && log.task.is_active}
+                        onChange={updateLog}
+                        onRemove={removeLog}
+                        onMoveUp={(i) => moveLog(i, 'up')}
+                        onMoveDown={(i) => moveLog(i, 'down')}
+                        onTaskUpdated={handleTaskUpdated}
+                        accentColor={color}
+                      />
+                    );
+                  })}
+                </div>
+              );
+            });
+          })()}
 
           {/* Day load (private) */}
           <div style={s.metaSection}>
@@ -541,15 +694,69 @@ export const DailyFormPage = () => {
 
           {/* Submit */}
           <div style={s.submitRow}>
-            <button
-              type="submit"
-              disabled={saving || !isEditable}
-              style={s.saveBtn}
-            >
-              {saving ? 'Saving…' : existingRecord ? 'Update Record' : 'Save Record'}
-            </button>
+            {checked ? (
+              <>
+                <span style={s.checkedBadge}>✓ Checked</span>
+                {windowState !== 'locked' && (
+                  <button
+                    type="button"
+                    onClick={() => setChecked(false)}
+                    style={{ ...s.navBtn, marginLeft: '0.75rem' }}
+                  >
+                    Re-edit
+                  </button>
+                )}
+              </>
+            ) : (
+              <button
+                type="submit"
+                disabled={saving || !isEditable}
+                style={s.saveBtn}
+              >
+                {saving ? 'Checking…' : 'Check'}
+              </button>
+            )}
           </div>
         </form>
+      )}
+
+      {/* Task create modal — rendered outside <form> to avoid nested form HTML */}
+      <TaskCreateModal
+        open={showTaskModal}
+        onClose={() => setShowTaskModal(false)}
+        onCreated={handleTaskCreated}
+        categories={categories}
+        projects={projects}
+        blockerTypes={blockerTypes}
+        onProjectCreated={(project) => setProjects((prev) => [...prev, project])}
+      />
+
+      {/* Check confirmation modal */}
+      {showConfirmCheck && (
+        <div style={s.modalOverlay}>
+          <div style={s.modalBox}>
+            <h3 style={{ margin: '0 0 0.75rem', fontSize: '1rem' }}>Confirm Check</h3>
+            <p style={{ margin: '0 0 1.25rem', color: '#4a5568', fontSize: '0.9rem' }}>
+              Submit today’s record? The form will be locked until you click Re-edit.
+            </p>
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '0.5rem' }}>
+              <button
+                type="button"
+                onClick={() => setShowConfirmCheck(false)}
+                style={s.navBtn}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmCheck}
+                style={s.saveBtn}
+              >
+                Confirm Check
+              </button>
+            </div>
+          </div>
+        </div>
       )}
 
       {/* Absence confirmed — show summary */}
@@ -586,6 +793,15 @@ const styles: Record<string, React.CSSProperties> = {
     marginBottom: '1rem',
   },
   dateTitle: { margin: 0, fontSize: '1.25rem', fontWeight: 700 },
+  datePicker: {
+    fontSize: '1rem',
+    fontWeight: 700,
+    border: '1px solid #cbd5e0',
+    borderRadius: '4px',
+    padding: '0.15rem 0.4rem',
+    cursor: 'pointer',
+    background: 'none',
+  },
   navBtn: {
     padding: '0.25rem 0.5rem',
     background: 'none',
@@ -692,5 +908,31 @@ const styles: Record<string, React.CSSProperties> = {
     cursor: 'pointer',
     fontWeight: 600,
     fontSize: '0.9rem',
+  },
+  checkedBadge: {
+    padding: '0.4rem 1rem',
+    background: '#c6f6d5',
+    color: '#276749',
+    borderRadius: '6px',
+    fontWeight: 600,
+    fontSize: '0.9rem',
+    border: '1px solid #9ae6b4',
+  },
+  modalOverlay: {
+    position: 'fixed' as const,
+    inset: 0,
+    background: 'rgba(0,0,0,0.4)',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    zIndex: 1000,
+  },
+  modalBox: {
+    background: '#fff',
+    borderRadius: '10px',
+    padding: '1.5rem',
+    width: '360px',
+    maxWidth: '90vw',
+    boxShadow: '0 10px 30px rgba(0,0,0,0.2)',
   },
 };


### PR DESCRIPTION
## What changed and why

Tasks that have no linked GitHub issue were not appearing in the daily work log because the task loading logic only fetched tasks with a `github_issue_url`. This fix ensures all active tasks — with or without a GitHub issue — are loaded and displayed.

Additional improvements included in the same scope:
- Date input replaces the static date title for easier navigation between days
- Category color mapping added to `WorkLogRow` for visual grouping with an accent color
- `updateTask` API call changed from `PATCH` to `PUT` to match the backend endpoint
- Task loading and error handling enhanced in the daily form

Closes #15

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [ ] CI/CD / infra
- [ ] Dependency upgrade

## Component(s) affected

- [ ] backend
- [x] frontend
- [ ] database schema / migration
- [ ] auth
- [ ] notifications / email
- [ ] LLM integration

## Testing done

- [x] Existing tests pass (`uv run pytest` / `yarn lint && tsc --noEmit`)
- [ ] New tests added (if applicable)
- [x] Manually tested locally

## Invariants checklist

- [ ] Edit window lock logic untouched or correctly updated
- [ ] Private fields (`day_load`, `blocker_text`) stripped for non-owners/non-leaders
- [ ] WebSocket visibility uses the same filter as REST
- [ ] `carried_from_id` is immutable after creation (not set or mutated here)
- [x] Exactly one `is_primary=true` tag per TaskEntry enforced (if task entry code touched) — UI enforces display validation; no save mutation bypasses this rule
- [ ] DailyRecord ↔ Absence mutual exclusion checked (if record creation/update touched)
- [ ] Soft-delete pattern used (no hard-delete on controlled lists)
- [ ] LLM user content injected in `<user_data>` delimiters (if LLM code touched)
- [x] N/A — edit window, visibility, WebSocket, carry-over, mutual exclusion, soft-delete, and LLM invariants are not touched by this change

## Screenshots (UI changes only)

<!-- Before: tasks without a GitHub issue URL were absent from the daily log work rows.
     After: all active tasks appear, grouped by category with a color accent in the left border. -->
