### PR TITLE
Add cancel/back button to all editor and form views

### DIFF
--- a/frontend/src/components/tasks/TaskCreateModal.tsx
+++ b/frontend/src/components/tasks/TaskCreateModal.tsx
@@ -159,6 +159,13 @@ export const TaskCreateModal = ({
     }
   };
 
+  const hasContent = !!(title || githubUrl || description || categoryId || projectId);
+
+  const handleClose = () => {
+    if (hasContent && !saving && !window.confirm('Discard unsaved task?')) return;
+    onClose();
+  };
+
   if (!open) return null;
 
   const selectedCategory = categories.find((c) => c.id === categoryId);
@@ -170,7 +177,7 @@ export const TaskCreateModal = ({
       <div style={s.panel}>
         <div style={s.header}>
           <h3 style={s.title}>New Task</h3>
-          <button type="button" onClick={onClose} style={s.closeBtn} aria-label="Close">
+          <button type="button" onClick={handleClose} style={s.closeBtn} aria-label="Close">
             ✕
           </button>
         </div>
@@ -367,7 +374,7 @@ export const TaskCreateModal = ({
           {formError && <p style={s.errorMsg}>{formError}</p>}
 
           <div style={s.footer}>
-            <button type="button" onClick={onClose} style={s.cancelBtn}>
+            <button type="button" onClick={handleClose} style={s.cancelBtn}>
               Cancel
             </button>
             <button type="submit" disabled={saving} style={s.saveBtn}>

--- a/frontend/src/pages/AdminListsPage.tsx
+++ b/frontend/src/pages/AdminListsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   getCategories,
   createCategory,
@@ -56,7 +57,7 @@ function ConfirmDialog({
 // Categories section
 // ---------------------------------------------------------------------------
 
-function CategoriesSection() {
+function CategoriesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }) {
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
   const [newCatName, setNewCatName] = useState('');
@@ -172,7 +173,7 @@ function CategoriesSection() {
           style={inputStyle}
           placeholder="New category name"
           value={newCatName}
-          onChange={(e) => setNewCatName(e.target.value)}
+          onChange={(e) => { setNewCatName(e.target.value); onDirtyChange(!!e.target.value.trim()); }}
           onKeyDown={(e) => e.key === 'Enter' && addCategory()}
         />
         <button style={primaryBtn} onClick={addCategory}>Add Category</button>
@@ -185,7 +186,7 @@ function CategoriesSection() {
 // Blocker types section
 // ---------------------------------------------------------------------------
 
-function BlockerTypesSection() {
+function BlockerTypesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }) {
   const [types, setTypes] = useState<BlockerType[]>([]);
   const [loading, setLoading] = useState(true);
   const [newName, setNewName] = useState('');
@@ -239,7 +240,7 @@ function BlockerTypesSection() {
           style={inputStyle}
           placeholder="New blocker type"
           value={newName}
-          onChange={(e) => setNewName(e.target.value)}
+          onChange={(e) => { setNewName(e.target.value); onDirtyChange(!!e.target.value.trim()); }}
           onKeyDown={(e) => e.key === 'Enter' && add()}
         />
         <button style={primaryBtn} onClick={add}>Add</button>
@@ -252,7 +253,7 @@ function BlockerTypesSection() {
 // Self-assessment tags section
 // ---------------------------------------------------------------------------
 
-function TagsSection() {
+function TagsSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }) {
   const [tags, setTags] = useState<SelfAssessmentTag[]>([]);
   const [loading, setLoading] = useState(true);
   const [editNames, setEditNames] = useState<Record<string, string>>({});
@@ -311,7 +312,7 @@ function TagsSection() {
           style={inputStyle}
           placeholder="New tag name"
           value={newTagName}
-          onChange={(e) => setNewTagName(e.target.value)}
+          onChange={(e) => { setNewTagName(e.target.value); onDirtyChange(!!e.target.value.trim()); }}
           onKeyDown={(e) => e.key === 'Enter' && add()}
         />
         <button style={primaryBtn} onClick={add}>Add Tag</button>
@@ -390,15 +391,34 @@ function AdminSettingsSection() {
 // Main page
 // ---------------------------------------------------------------------------
 
-export const AdminListsPage = () => (
-  <div style={{ maxWidth: '800px', margin: '0 auto' }}>
-    <h2 style={{ marginBottom: '1rem' }}>Controlled Lists (Admin)</h2>
-    <AdminSettingsSection />
-    <CategoriesSection />
-    <BlockerTypesSection />
-    <TagsSection />
-  </div>
-);
+export const AdminListsPage = () => {
+  const navigate = useNavigate();
+  const [catDirty, setCatDirty] = useState(false);
+  const [blockerDirty, setBlockerDirty] = useState(false);
+  const [tagDirty, setTagDirty] = useState(false);
+  const isDirty = catDirty || blockerDirty || tagDirty;
+
+  const handleBack = () => {
+    if (isDirty && !window.confirm('You have unsaved changes. Leave anyway?')) return;
+    navigate('/');
+  };
+
+  return (
+    <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+      <button
+        onClick={handleBack}
+        style={{ background: 'none', border: 'none', color: 'var(--primary)', cursor: 'pointer', padding: 0, fontSize: '0.85rem', marginBottom: '1rem', display: 'block' }}
+      >
+        ← Back
+      </button>
+      <h2 style={{ marginBottom: '1rem' }}>Controlled Lists (Admin)</h2>
+      <AdminSettingsSection />
+      <CategoriesSection onDirtyChange={setCatDirty} />
+      <BlockerTypesSection onDirtyChange={setBlockerDirty} />
+      <TagsSection onDirtyChange={setTagDirty} />
+    </div>
+  );
+};
 
 // ---------------------------------------------------------------------------
 // Styles

--- a/frontend/src/pages/AdminTeamDetailPage.tsx
+++ b/frontend/src/pages/AdminTeamDetailPage.tsx
@@ -40,7 +40,7 @@ function ConfirmDialog({
 // Rename section
 // ---------------------------------------------------------------------------
 
-function RenameSection({ teamId, currentName, onRenamed }: { teamId: string; currentName: string; onRenamed: (name: string) => void }) {
+function RenameSection({ teamId, currentName, onRenamed, onDirtyChange }: { teamId: string; currentName: string; onRenamed: (name: string) => void; onDirtyChange: (dirty: boolean) => void }) {
   const [name, setName] = useState(currentName);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
@@ -58,6 +58,7 @@ function RenameSection({ teamId, currentName, onRenamed }: { teamId: string; cur
     try {
       const updated = await renameTeam(teamId, trimmed);
       onRenamed(updated.name);
+      onDirtyChange(false);
       setSaved(true);
     } catch {
       setError('Failed to rename team. Please try again.');
@@ -73,7 +74,7 @@ function RenameSection({ teamId, currentName, onRenamed }: { teamId: string; cur
         <input
           style={{ ...inputStyle, flex: 1 }}
           value={name}
-          onChange={(e) => { setName(e.target.value); setSaved(false); setError(''); }}
+          onChange={(e) => { setName(e.target.value); setSaved(false); setError(''); onDirtyChange(e.target.value.trim() !== currentName.trim()); }}
           onKeyDown={(e) => e.key === 'Enter' && save()}
         />
         <button style={primaryBtn} onClick={save} disabled={saving}>
@@ -273,6 +274,12 @@ export const AdminTeamDetailPage = () => {
   const navigate = useNavigate();
   const [teamName, setTeamName] = useState('');
   const [membersKey, setMembersKey] = useState(0); // bump to trigger MembersSection reload
+  const [isDirty, setIsDirty] = useState(false);
+
+  const handleBack = () => {
+    if (isDirty && !window.confirm('You have unsaved changes. Leave anyway?')) return;
+    navigate('/admin/teams');
+  };
 
   // We don't have a single-team GET endpoint, so resolve the name from the members section
   // or simply let the rename section show an empty field initially.
@@ -294,7 +301,7 @@ export const AdminTeamDetailPage = () => {
     <div style={{ maxWidth: '800px', margin: '0 auto' }}>
       <button
         style={{ ...tinyBtn, marginBottom: '1rem' }}
-        onClick={() => navigate('/admin/teams')}
+        onClick={handleBack}
       >
         ← Back to Teams
       </button>
@@ -306,6 +313,7 @@ export const AdminTeamDetailPage = () => {
         teamId={teamId}
         currentName={teamName}
         onRenamed={(name) => setTeamName(name)}
+        onDirtyChange={setIsDirty}
       />
       <MembersSection key={membersKey} teamId={teamId} />
       <AssignUserSection teamId={teamId} onAssigned={() => setMembersKey((k) => k + 1)} />

--- a/frontend/src/pages/DailyFormPage.tsx
+++ b/frontend/src/pages/DailyFormPage.tsx
@@ -167,6 +167,9 @@ export const DailyFormPage = () => {
   // Task create modal
   const [showTaskModal, setShowTaskModal] = useState(false);
 
+  // Dirty tracking — set on first user interaction, reset after successful save
+  const isDirty = useRef(false);
+
   // Edit window
   const windowState = useMemo(
     () => getEditWindowState(recordDate, formOpenedAt.current),
@@ -193,6 +196,7 @@ export const DailyFormPage = () => {
     setSuccessMsg(null);
     setChecked(false);
     setShowConfirmCheck(false);
+    isDirty.current = false;
     (async () => {
       try {
         const [cats, tagList, btList, projs, records, absences, grants, activeTasks] =
@@ -284,12 +288,14 @@ export const DailyFormPage = () => {
   // Work log manipulation
   const updateLog = useCallback(
     (index: number, updated: Partial<DailyWorkLogFormEntry>) => {
+      isDirty.current = true;
       setWorkLogs((prev) => prev.map((l, i) => (i === index ? { ...l, ...updated } : l)));
     },
     []
   );
 
   const removeLog = useCallback((index: number) => {
+    isDirty.current = true;
     setWorkLogs((prev) => prev.filter((_, i) => i !== index));
   }, []);
 
@@ -452,6 +458,7 @@ export const DailyFormPage = () => {
       }
       setSuccessMsg('Record checked.');
       setChecked(true);
+      isDirty.current = false;
     } catch (err: unknown) {
       const msg =
         (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail ??
@@ -468,9 +475,15 @@ export const DailyFormPage = () => {
 
   // Navigate dates
   const goToDate = (offset: number) => {
+    if (isDirty.current && !window.confirm('You have unsaved changes. Leave anyway?')) return;
     const d = new Date(recordDate);
     d.setDate(d.getDate() + offset);
     navigate(`/daily/${d.toISOString().slice(0, 10)}`);
+  };
+
+  const handleCancel = () => {
+    if (isDirty.current && !window.confirm('You have unsaved changes. Leave anyway?')) return;
+    navigate('/');
   };
 
   const s = styles;
@@ -503,6 +516,13 @@ export const DailyFormPage = () => {
           style={{ ...s.navBtn, marginLeft: '1rem' }}
         >
           Today
+        </button>
+        <button
+          type="button"
+          onClick={handleCancel}
+          style={{ ...s.navBtn, marginLeft: 'auto', color: 'var(--text-secondary)' }}
+        >
+          ✕ Cancel
         </button>
       </div>
 
@@ -667,7 +687,7 @@ export const DailyFormPage = () => {
                 max={5}
                 step={1}
                 value={dayLoad}
-                onChange={(e) => setDayLoad(Number(e.target.value))}
+                onChange={(e) => { isDirty.current = true; setDayLoad(Number(e.target.value)); }}
                 disabled={!isEditable}
                 style={{ width: '10rem', margin: '0 0.75rem' }}
               />
@@ -679,7 +699,7 @@ export const DailyFormPage = () => {
               <label style={s.label}>Day note</label>
               <textarea
                 value={dayNote}
-                onChange={(e) => setDayNote(e.target.value)}
+                onChange={(e) => { isDirty.current = true; setDayNote(e.target.value); }}
                 disabled={!isEditable}
                 rows={3}
                 style={{ ...s.input, resize: 'vertical' }}

--- a/frontend/src/pages/NotificationPreferencesPage.tsx
+++ b/frontend/src/pages/NotificationPreferencesPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   getNotificationPreferences,
   updateNotificationPreferences,
@@ -40,6 +41,7 @@ function Toggle({ checked, disabled, onChange }: { checked: boolean; disabled?: 
 }
 
 export const NotificationPreferencesPage = () => {
+  const navigate = useNavigate();
   const [prefs, setPrefs] = useState<NotificationPreference[]>([]);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -71,6 +73,12 @@ export const NotificationPreferencesPage = () => {
 
   return (
     <div style={{ maxWidth: '600px', margin: '0 auto' }}>
+      <button
+        onClick={() => navigate('/')}
+        style={{ background: 'none', border: 'none', color: 'var(--primary)', cursor: 'pointer', padding: 0, fontSize: '0.85rem', marginBottom: '1rem', display: 'block' }}
+      >
+        ← Back
+      </button>
       <h2>Notification Preferences</h2>
       <table style={{ width: '100%', borderCollapse: 'collapse' }}>
         <thead>

--- a/frontend/src/pages/OnboardingPage.tsx
+++ b/frontend/src/pages/OnboardingPage.tsx
@@ -32,6 +32,14 @@ export const OnboardingPage = () => {
 
   return (
     <div style={{ maxWidth: '480px', margin: '4rem auto', padding: '2rem', textAlign: 'center' }}>
+      <div style={{ textAlign: 'right', marginBottom: '0.5rem' }}>
+        <button
+          onClick={handleSignOut}
+          style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: '0.85rem' }}
+        >
+          ✕ Cancel
+        </button>
+      </div>
       <h1 style={{ fontSize: '1.5rem', fontWeight: 700 }}>{t('onboarding.title')}</h1>
       <p style={{ color: 'var(--text-secondary)', marginBottom: '2rem' }}>{t('onboarding.subtitle')}</p>
       <div style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', marginBottom: '2rem' }}>

--- a/frontend/src/pages/QuarterlyReportPage.tsx
+++ b/frontend/src/pages/QuarterlyReportPage.tsx
@@ -76,11 +76,22 @@ export const QuarterlyReportPage = () => {
     }
   };
 
+  const handleBack = () => {
+    if (isDraft && !window.confirm('You may have unsaved section edits. Leave anyway?')) return;
+    navigate(-1);
+  };
+
   const isDraft = report?.status === 'draft';
   const isFinalized = report?.status === 'finalized';
 
   return (
     <div style={{ maxWidth: '800px', margin: '0 auto' }}>
+      <button
+        onClick={handleBack}
+        style={{ background: 'none', border: 'none', color: 'var(--primary)', cursor: 'pointer', padding: 0, fontSize: '0.85rem', marginBottom: '1rem', display: 'block' }}
+      >
+        ← Back
+      </button>
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '1.5rem', flexWrap: 'wrap', gap: '0.75rem' }}>
         <h1 style={{ margin: 0, fontSize: '1.5rem', fontWeight: 700 }}>Quarterly Report</h1>
         <div style={{ display: 'flex', gap: '0.75rem', alignItems: 'center' }}>

--- a/frontend/src/pages/TeamBalanceSettingsPage.tsx
+++ b/frontend/src/pages/TeamBalanceSettingsPage.tsx
@@ -1,13 +1,16 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
 import { getTeamSettings, updateTeamSettings, type TeamSettings } from '../api/teams';
 
 export const TeamBalanceSettingsPage = () => {
+  const navigate = useNavigate();
   const { user } = useAuthStore();
   const teamId = user?.team?.id;
 
   const [settings, setSettings] = useState<TeamSettings | null>(null);
   const [targets, setTargets] = useState<Record<string, number>>({});
+  const [initialTargets, setInitialTargets] = useState<Record<string, number>>({});
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState('');
@@ -17,6 +20,7 @@ export const TeamBalanceSettingsPage = () => {
     getTeamSettings(teamId).then((s) => {
       setSettings(s);
       setTargets({ ...s.balance_targets });
+      setInitialTargets({ ...s.balance_targets });
     });
   }, [teamId]);
 
@@ -28,6 +32,7 @@ export const TeamBalanceSettingsPage = () => {
     setError('');
     try {
       await updateTeamSettings(teamId, { balance_targets: targets });
+      setInitialTargets({ ...targets });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch {
@@ -35,6 +40,13 @@ export const TeamBalanceSettingsPage = () => {
     } finally {
       setSaving(false);
     }
+  };
+
+  const isDirty = JSON.stringify(targets) !== JSON.stringify(initialTargets);
+
+  const handleBack = () => {
+    if (isDirty && !window.confirm('You have unsaved changes. Leave anyway?')) return;
+    navigate('/team');
   };
 
   if (!teamId) return <div>Not assigned to a team.</div>;
@@ -82,7 +94,7 @@ export const TeamBalanceSettingsPage = () => {
           {saving ? 'Saving…' : 'Save'}
         </button>
         {saved && <span style={{ color: 'var(--success)', fontSize: '0.85rem', alignSelf: 'center' }}>Saved ✓</span>}
-        <a href="/team" style={{ alignSelf: 'center', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>← Back</a>
+        <button onClick={handleBack} style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: '0.85rem', alignSelf: 'center' }}>← Back</button>
       </div>
     </div>
   );

--- a/frontend/src/pages/TeamThresholdSettingsPage.tsx
+++ b/frontend/src/pages/TeamThresholdSettingsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
 import { getTeamSettings, updateTeamSettings, type TeamSettings } from '../api/teams';
 
@@ -15,15 +16,19 @@ const FIELDS: { key: keyof ThresholdField; label: string; min: number; max: numb
 ];
 
 export const TeamThresholdSettingsPage = () => {
+  const navigate = useNavigate();
   const { user } = useAuthStore();
   const teamId = user?.team?.id;
 
-  const [values, setValues] = useState<ThresholdField>({
+  const defaultValues: ThresholdField = {
     overload_load_threshold: 4,
     overload_streak_days: 3,
     fragmentation_task_threshold: 8,
     carryover_aging_days: 5,
-  });
+  };
+
+  const [values, setValues] = useState<ThresholdField>(defaultValues);
+  const [initialValues, setInitialValues] = useState<ThresholdField>(defaultValues);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState('');
@@ -31,12 +36,14 @@ export const TeamThresholdSettingsPage = () => {
   useEffect(() => {
     if (!teamId) return;
     getTeamSettings(teamId).then((s) => {
-      setValues({
+      const loaded: ThresholdField = {
         overload_load_threshold: s.overload_load_threshold,
         overload_streak_days: s.overload_streak_days,
         fragmentation_task_threshold: s.fragmentation_task_threshold,
         carryover_aging_days: s.carryover_aging_days,
-      });
+      };
+      setValues(loaded);
+      setInitialValues(loaded);
     });
   }, [teamId]);
 
@@ -46,6 +53,7 @@ export const TeamThresholdSettingsPage = () => {
     setError('');
     try {
       await updateTeamSettings(teamId, values);
+      setInitialValues({ ...values });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch {
@@ -53,6 +61,15 @@ export const TeamThresholdSettingsPage = () => {
     } finally {
       setSaving(false);
     }
+  };
+
+  const isDirty = (Object.keys(values) as (keyof ThresholdField)[]).some(
+    (k) => values[k] !== initialValues[k]
+  );
+
+  const handleBack = () => {
+    if (isDirty && !window.confirm('You have unsaved changes. Leave anyway?')) return;
+    navigate('/team');
   };
 
   if (!teamId) return <div>Not assigned to a team.</div>;
@@ -96,7 +113,7 @@ export const TeamThresholdSettingsPage = () => {
           {saving ? 'Saving…' : 'Save'}
         </button>
         {saved && <span style={{ color: 'var(--success)', fontSize: '0.85rem', alignSelf: 'center' }}>Saved ✓</span>}
-        <a href="/team" style={{ alignSelf: 'center', fontSize: '0.85rem', color: 'var(--text-secondary)' }}>← Back</a>
+        <button onClick={handleBack} style={{ background: 'none', border: 'none', color: 'var(--text-secondary)', cursor: 'pointer', fontSize: '0.85rem', alignSelf: 'center' }}>← Back</button>
       </div>
     </div>
   );

--- a/frontend/src/pages/UnlockPage.tsx
+++ b/frontend/src/pages/UnlockPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { useAuthStore } from '../stores/authStore';
 import { getTeamMembers, type TeamMember } from '../api/teams';
 import {
@@ -9,6 +10,7 @@ import {
 } from '../api/reports';
 
 export const UnlockPage = () => {
+  const navigate = useNavigate();
   const user = useAuthStore((s) => s.user);
   const teamId = user?.team?.id ?? null;
 
@@ -85,6 +87,12 @@ export const UnlockPage = () => {
 
   return (
     <div style={{ maxWidth: 700, margin: '0 auto' }}>
+      <button
+        onClick={() => navigate('/team')}
+        style={{ background: 'none', border: 'none', color: 'var(--primary)', cursor: 'pointer', padding: 0, fontSize: '0.85rem', marginBottom: '1rem', display: 'block' }}
+      >
+        ← Back
+      </button>
       <h2 style={{ marginBottom: '0.25rem' }}>Unlock Edit Window</h2>
       <p style={{ color: 'var(--text-secondary)', fontSize: '0.85rem', marginBottom: '1.5rem' }}>
         Grant a member access to edit a specific past date after the edit window has closed.

--- a/frontend/src/pages/WeeklyReportPage.tsx
+++ b/frontend/src/pages/WeeklyReportPage.tsx
@@ -266,6 +266,12 @@ export const WeeklyReportPage = () => {
 
   return (
     <div style={{ maxWidth: '900px', margin: '0 auto' }}>
+      <button
+        onClick={() => navigate('/')}
+        style={{ background: 'none', border: 'none', color: 'var(--primary)', cursor: 'pointer', padding: 0, fontSize: '0.85rem', marginBottom: '1rem', display: 'block' }}
+      >
+        ← Back to Dashboard
+      </button>
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem', flexWrap: 'wrap', gap: '0.5rem' }}>
         <h2 style={{ margin: 0 }}>Weekly Report</h2>
         <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center' }}>


### PR DESCRIPTION
## What changed and why

Add cancel/back affordances to every editor and form view in the frontend so users can abandon an edit and return to the previous view without submitting unintended changes.

Closes #16

**Pages updated:**
- `DailyFormPage` — `✕ Cancel` button in date header; dirty flag on any `onChange`; date navigation also guarded
- `QuarterlyReportPage` — `← Back` button; confirms if report is in draft state
- `WeeklyReportPage` — page-level `← Back to Dashboard` button
- `TeamBalanceSettingsPage` — converted hard `<a>` to `useNavigate`; stores `initialTargets`; confirms if dirty
- `TeamThresholdSettingsPage` — same pattern; `initialValues` comparison
- `AdminTeamDetailPage` — `onDirtyChange` callback from `RenameSection` to parent; back button confirms if name edited
- `AdminListsPage` — converted to stateful component; `onDirtyChange` from each sub-section; `← Back` button
- `NotificationPreferencesPage` — `← Back` button → `/`
- `UnlockPage` — `← Back` button → `/team`
- `OnboardingPage` — `✕ Cancel` button (triggers sign-out, the only meaningful escape from lobby state)

**Component updated:**
- `TaskCreateModal` — `handleClose` wraps `onClose` with `window.confirm("Discard unsaved task?")` when any field has content; both `✕` header button and footer Cancel button updated

`CommentInput` and `CommentThread` already had correct cancel affordances — no changes needed.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [ ] CI/CD / infra
- [ ] Dependency upgrade

## Component(s) affected

- [ ] backend
- [x] frontend
- [ ] database schema / migration
- [ ] auth
- [ ] notifications / email
- [ ] LLM integration

## Testing done

- [x] Existing tests pass (`uv run pytest` / `yarn lint && tsc --noEmit`)
- [ ] New tests added (if applicable)
- [x] Manually tested locally

Manual testing steps:
1. Navigate to each affected page — verify Cancel/Back button is visible
2. Edit a field → click Cancel/Back → confirm dialog appears → OK navigates away
3. Edit a field → click Cancel/Back → click Cancel on dialog → stays on page
4. `TaskCreateModal`: type title → click ✕ → confirm dialog; empty form → click ✕ → no dialog
5. Submit/save flows are unaffected

## Invariants checklist

- [x] N/A — none of the above apply to this change

This PR touches only UI navigation/UX. No backend logic, edit window locking, visibility filters, tag validation, absence/record mutual exclusion, soft-delete patterns, or LLM integrations were modified.
