### PR TITLE
Add absence types management and local login

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -60,6 +60,7 @@ Rules that MUST be followed in every coding task. Violating any of these is a bu
 - Backend: Python FastAPI. Use **uv** for dependency management (not pip, poetry, pipenv).
 - Frontend: React + TypeScript + Vite + React Router. Use **yarn** (not npm, pnpm).
 - Monorepo: `backend/` and `frontend/` directories at repo root.
+- All GitHub operations (create/view issues, PRs, labels, milestones, releases, etc.) use **`gh` CLI** (not the GitHub REST API directly, not `curl`, not the GitHub web UI).
 
 ## Code Style
 

--- a/backend/alembic/versions/b1c4e7f2a935_add_local_login_fields_to_users.py
+++ b/backend/alembic/versions/b1c4e7f2a935_add_local_login_fields_to_users.py
@@ -1,0 +1,39 @@
+"""add local login fields to users
+
+Revision ID: b1c4e7f2a935
+Revises: 3a8f2c1d9e47
+Create Date: 2026-04-19 00:00:00.000000
+
+Adds two columns to the users table to support the narrow bootstrap/recovery
+local login feature:
+  - password_hash: nullable TEXT to store bcrypt hash (NULL for SSO-only users)
+  - allow_local_login: BOOLEAN NOT NULL DEFAULT false (only the seeded admin has true)
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "b1c4e7f2a935"
+down_revision: Union[str, Sequence[str], None] = "3a8f2c1d9e47"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("users", sa.Column("password_hash", sa.Text(), nullable=True))
+    op.add_column(
+        "users",
+        sa.Column(
+            "allow_local_login",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "allow_local_login")
+    op.drop_column("users", "password_hash")

--- a/backend/alembic/versions/e2f4a6b8c0d1_absence_type_fk_table.py
+++ b/backend/alembic/versions/e2f4a6b8c0d1_absence_type_fk_table.py
@@ -1,0 +1,114 @@
+"""Replace AbsenceType StrEnum with FK-backed absence_types table
+
+Revision ID: e2f4a6b8c0d1
+Revises: b1c4e7f2a935
+Create Date: 2026-04-19 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "e2f4a6b8c0d1"
+down_revision: Union[str, Sequence[str], None] = "b1c4e7f2a935"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+# Fixed UUIDs must match ABSENCE_TYPE_UUIDS in app/db/models/absence.py
+_ABSENCE_TYPES = [
+    ("a1b2c3d4-e5f6-7890-abcd-ef1234567890", "holiday"),
+    ("b2c3d4e5-f6a7-8901-bcde-f12345678901", "exchanged_holiday"),
+    ("c3d4e5f6-a7b8-9012-cdef-123456789012", "illness"),
+    ("d4e5f6a7-b8c9-0123-defa-234567890123", "other"),
+]
+
+# Map old enum string → new UUID (for backfill)
+_ENUM_TO_UUID = {name: uid for uid, name in _ABSENCE_TYPES}
+
+
+def upgrade() -> None:
+    # 1. Create the new absence_types table
+    op.create_table(
+        "absence_types",
+        sa.Column("id", sa.Uuid(), nullable=False),
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    # 2. Seed the 4 default rows with fixed UUIDs
+    absence_types_table = sa.table(
+        "absence_types",
+        sa.column("id", sa.Uuid()),
+        sa.column("name", sa.String()),
+        sa.column("is_active", sa.Boolean()),
+    )
+    op.bulk_insert(
+        absence_types_table,
+        [{"id": uid, "name": name, "is_active": True} for uid, name in _ABSENCE_TYPES],
+    )
+
+    # 3. Add absence_type_id column as nullable first (for backfill)
+    op.add_column(
+        "absences",
+        sa.Column("absence_type_id", sa.Uuid(), nullable=True),
+    )
+
+    # 4. Backfill: map old string values to fixed UUIDs
+    conn = op.get_bind()
+    for enum_val, uuid_val in _ENUM_TO_UUID.items():
+        conn.execute(
+            sa.text(
+                "UPDATE absences SET absence_type_id = :uid"
+                " WHERE absence_type = :val"
+            ),
+            {"uid": uuid_val, "val": enum_val},
+        )
+
+    # 5. Make absence_type_id NOT NULL
+    op.alter_column("absences", "absence_type_id", nullable=False)
+
+    # 6. Add FK constraint
+    op.create_foreign_key(
+        "fk_absences_absence_type_id",
+        "absences",
+        "absence_types",
+        ["absence_type_id"],
+        ["id"],
+    )
+
+    # 7. Drop the old string column
+    #    (native_enum=False used VARCHAR — no PG enum type to drop)
+    op.drop_column("absences", "absence_type")
+
+
+def downgrade() -> None:
+    # 1. Add the old string column back (nullable first)
+    op.add_column(
+        "absences",
+        sa.Column("absence_type", sa.String(), nullable=True),
+    )
+
+    # 2. Backfill: map UUIDs back to string values
+    conn = op.get_bind()
+    for uuid_val, enum_val in _ABSENCE_TYPES:
+        conn.execute(
+            sa.text(
+                "UPDATE absences SET absence_type = :val"
+                " WHERE absence_type_id = :uid"
+            ),
+            {"val": enum_val, "uid": uuid_val},
+        )
+
+    # 3. Make absence_type NOT NULL
+    op.alter_column("absences", "absence_type", nullable=False)
+
+    # 4. Drop FK constraint and absence_type_id column
+    op.drop_constraint("fk_absences_absence_type_id", "absences", type_="foreignkey")
+    op.drop_column("absences", "absence_type_id")
+
+    # 5. Drop the absence_types table
+    op.drop_table("absence_types")

--- a/backend/app/api/v1/__init__.py
+++ b/backend/app/api/v1/__init__.py
@@ -1,5 +1,6 @@
 from fastapi import APIRouter
 
+from .absence_types import router as absence_types_router
 from .absences import router as absences_router
 from .admin_settings import router as admin_settings_router
 from .auth import router as auth_router
@@ -35,6 +36,7 @@ router.include_router(tasks_router)
 router.include_router(daily_records_router)
 router.include_router(unlock_router)
 router.include_router(absences_router)
+router.include_router(absence_types_router)
 router.include_router(team_settings_router)
 router.include_router(metrics_router)
 router.include_router(growth_router)

--- a/backend/app/api/v1/absence_types.py
+++ b/backend/app/api/v1/absence_types.py
@@ -1,0 +1,76 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.deps import require_active_user, require_admin
+from app.db.engine import get_db
+from app.db.models.absence import AbsenceType
+from app.db.models.user import User
+from app.db.schemas.absence import (
+    AbsenceTypeCreate,
+    AbsenceTypeResponse,
+    AbsenceTypeUpdate,
+)
+
+router = APIRouter(tags=["absence-types"])
+
+
+@router.post(
+    "/absence-types",
+    response_model=AbsenceTypeResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_absence_type(
+    body: AbsenceTypeCreate,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+):
+    at = AbsenceType(id=uuid.uuid4(), name=body.name, is_active=True)
+    db.add(at)
+    await db.commit()
+    await db.refresh(at)
+    return AbsenceTypeResponse.model_validate(at)
+
+
+@router.get("/absence-types", response_model=list[AbsenceTypeResponse])
+async def list_absence_types(
+    include_inactive: bool = False,
+    db: AsyncSession = Depends(get_db),
+    current_user: User = Depends(require_active_user),
+):
+    if include_inactive and not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
+        )
+
+    q = select(AbsenceType)
+    if not include_inactive:
+        q = q.where(AbsenceType.is_active.is_(True))
+    result = await db.execute(q.order_by(AbsenceType.name))
+    return [AbsenceTypeResponse.model_validate(at) for at in result.scalars().all()]
+
+
+@router.patch("/absence-types/{at_id}", response_model=AbsenceTypeResponse)
+async def update_absence_type(
+    at_id: uuid.UUID,
+    body: AbsenceTypeUpdate,
+    db: AsyncSession = Depends(get_db),
+    _admin: User = Depends(require_admin),
+):
+    result = await db.execute(select(AbsenceType).where(AbsenceType.id == at_id))
+    at = result.scalar_one_or_none()
+    if at is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="AbsenceType not found"
+        )
+
+    if body.name is not None:
+        at.name = body.name
+    if body.is_active is not None:
+        at.is_active = body.is_active
+
+    await db.commit()
+    await db.refresh(at)
+    return AbsenceTypeResponse.model_validate(at)

--- a/backend/app/api/v1/absences.py
+++ b/backend/app/api/v1/absences.py
@@ -11,7 +11,6 @@ from app.core.deps import get_current_user, require_active_user, require_leader
 from app.core.edit_window import check_edit_window
 from app.db.engine import get_db
 from app.db.models.absence import Absence, UnlockGrant
-from app.db.models.absence import AbsenceType as AbsenceTypeEnum
 from app.db.models.daily_record import DailyRecord
 from app.db.models.team import TeamMembership
 from app.db.models.user import User
@@ -144,7 +143,7 @@ async def create_absence(
     absence = Absence(
         user_id=current_user.id,
         record_date=body.record_date,
-        absence_type=body.absence_type,
+        absence_type_id=body.absence_type_id,
         note=body.note,
     )
     db.add(absence)
@@ -219,8 +218,8 @@ async def update_absence(
         current_user.id, absence.record_date, body.form_opened_at, db
     )
 
-    if body.absence_type is not None:
-        absence.absence_type = AbsenceTypeEnum(body.absence_type)
+    if body.absence_type_id is not None:
+        absence.absence_type_id = body.absence_type_id
     if body.note is not None:
         absence.note = body.note
 

--- a/backend/app/api/v1/absences.py
+++ b/backend/app/api/v1/absences.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.deps import get_current_user, require_active_user, require_leader
 from app.core.edit_window import check_edit_window
 from app.db.engine import get_db
-from app.db.models.absence import Absence, UnlockGrant
+from app.db.models.absence import Absence, AbsenceType, UnlockGrant
 from app.db.models.daily_record import DailyRecord
 from app.db.models.team import TeamMembership
 from app.db.models.user import User
@@ -140,6 +140,16 @@ async def create_absence(
             detail="An absence is already recorded for this date.",
         )
 
+    # FK validation: absence_type_id must reference an existing AbsenceType
+    at_check = await db.execute(
+        select(AbsenceType).where(AbsenceType.id == body.absence_type_id)
+    )
+    if at_check.scalar_one_or_none() is None:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail="absence_type_id does not reference a known absence type.",
+        )
+
     absence = Absence(
         user_id=current_user.id,
         record_date=body.record_date,
@@ -219,6 +229,14 @@ async def update_absence(
     )
 
     if body.absence_type_id is not None:
+        at_check = await db.execute(
+            select(AbsenceType).where(AbsenceType.id == body.absence_type_id)
+        )
+        if at_check.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail="absence_type_id does not reference a known absence type.",
+            )
         absence.absence_type_id = body.absence_type_id
     if body.note is not None:
         absence.note = body.note

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -4,15 +4,17 @@ import secrets
 from urllib.parse import urlencode
 
 import httpx
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import RedirectResponse
 from jose import jwt as jose_jwt
+from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.v1.social import limiter
 from app.config import settings
 from app.core.deps import get_current_user
-from app.core.security import create_access_token
+from app.core.security import create_access_token, verify_password
 from app.db.engine import get_db
 from app.db.models.team import Team, TeamMembership
 from app.db.models.user import User
@@ -121,6 +123,41 @@ async def callback(
 @router.post("/logout")
 async def logout():
     return {"message": "Logged out"}
+
+
+class LocalLoginRequest(BaseModel):
+    email: str
+    password: str
+
+
+_INVALID_CREDENTIALS = HTTPException(
+    status_code=401,
+    detail="Invalid credentials",
+    headers={"WWW-Authenticate": "Bearer"},
+)
+
+
+@router.post("/local-login")
+@limiter.limit("5/15minute")
+async def local_login(
+    request: Request,
+    body: LocalLoginRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    result = await db.execute(select(User).where(User.email == body.email))
+    user = result.scalar_one_or_none()
+
+    # Generic rejection — never reveal whether the email exists or why login failed
+    if user is None or not user.allow_local_login or user.password_hash is None:
+        raise _INVALID_CREDENTIALS
+
+    if not verify_password(body.password, user.password_hash):
+        raise _INVALID_CREDENTIALS
+
+    access_token = create_access_token(
+        {"sub": str(user.id), "is_leader": user.is_leader, "is_admin": user.is_admin}
+    )
+    return {"access_token": access_token, "token_type": "bearer"}
 
 
 @router.get("/me")

--- a/backend/app/api/v1/export.py
+++ b/backend/app/api/v1/export.py
@@ -490,7 +490,7 @@ async def export_bulk(
                 str(a.id),
                 str(a.user_id),
                 str(a.record_date),
-                a.absence_type,
+                a.absence_type.name,
                 a.note or "",
             ]
             for a in absences

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     FRONTEND_URL: str = "http://localhost:5173"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 480
     ADMIN_EMAIL: str | None = None
+    # Required in non-local environments; app refuses to start if unset or weak
+    ADMIN_PASSWORD: str | None = None
     OPENAI_API_KEY: str | None = None
     OPENAI_API_BASE: str | None = None
     GITHUB_TOKEN: str | None = None

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -11,7 +11,9 @@ _BCRYPT_ROUNDS = 12
 
 
 def hash_password(password: str) -> str:
-    return bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=_BCRYPT_ROUNDS)).decode()
+    return bcrypt.hashpw(
+        password.encode(), bcrypt.gensalt(rounds=_BCRYPT_ROUNDS)
+    ).decode()
 
 
 def verify_password(plain: str, hashed: str) -> bool:

--- a/backend/app/core/security.py
+++ b/backend/app/core/security.py
@@ -1,11 +1,21 @@
 from datetime import UTC, datetime, timedelta
 
+import bcrypt
 from fastapi import HTTPException, status
 from jose import JWTError, jwt
 
 from app.config import settings
 
 ALGORITHM = "HS256"
+_BCRYPT_ROUNDS = 12
+
+
+def hash_password(password: str) -> str:
+    return bcrypt.hashpw(password.encode(), bcrypt.gensalt(rounds=_BCRYPT_ROUNDS)).decode()
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return bcrypt.checkpw(plain.encode(), hashed.encode())
 
 
 def create_access_token(data: dict, expires_delta: timedelta | None = None) -> str:

--- a/backend/app/db/models/absence.py
+++ b/backend/app/db/models/absence.py
@@ -1,29 +1,38 @@
-import enum
 import uuid
 from datetime import date, datetime
 
 from sqlalchemy import (
+    Boolean,
     Date,
     DateTime,
     ForeignKey,
+    String,
     Text,
     UniqueConstraint,
     Uuid,
     func,
 )
-from sqlalchemy import (
-    Enum as SAEnum,
-)
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from . import Base
 
+# Fixed UUIDs for the 4 default absence types — shared by migration and seed.
+ABSENCE_TYPE_UUIDS: dict[str, uuid.UUID] = {
+    "holiday": uuid.UUID("a1b2c3d4-e5f6-7890-abcd-ef1234567890"),
+    "exchanged_holiday": uuid.UUID("b2c3d4e5-f6a7-8901-bcde-f12345678901"),
+    "illness": uuid.UUID("c3d4e5f6-a7b8-9012-cdef-123456789012"),
+    "other": uuid.UUID("d4e5f6a7-b8c9-0123-defa-234567890123"),
+}
 
-class AbsenceType(enum.StrEnum):
-    holiday = "holiday"
-    exchanged_holiday = "exchanged_holiday"
-    illness = "illness"
-    other = "other"
+
+class AbsenceType(Base):
+    __tablename__ = "absence_types"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
 
 
 class Absence(Base):
@@ -38,9 +47,10 @@ class Absence(Base):
         Uuid(as_uuid=True), ForeignKey("users.id"), nullable=False
     )
     record_date: Mapped[date] = mapped_column(Date, nullable=False)
-    absence_type: Mapped[AbsenceType] = mapped_column(
-        SAEnum(AbsenceType, name="absence_type", native_enum=False), nullable=False
+    absence_type_id: Mapped[uuid.UUID] = mapped_column(
+        Uuid(as_uuid=True), ForeignKey("absence_types.id"), nullable=False
     )
+    absence_type: Mapped["AbsenceType"] = relationship("AbsenceType", lazy="joined")
     note: Mapped[str] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/db/models/user.py
+++ b/backend/app/db/models/user.py
@@ -21,6 +21,11 @@ class User(Base):
     )
     # MS Graph API delegated token for Mail.Send (stored as opaque encrypted string in prod)
     ms_graph_refresh_token: Mapped[str] = mapped_column(Text, nullable=True)
+    # Local (non-SSO) login support — only the seeded admin account uses these
+    password_hash: Mapped[str | None] = mapped_column(Text, nullable=True)
+    allow_local_login: Mapped[bool] = mapped_column(
+        Boolean, default=False, nullable=False, server_default="false"
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )

--- a/backend/app/db/schemas/absence.py
+++ b/backend/app/db/schemas/absence.py
@@ -2,22 +2,36 @@ from __future__ import annotations
 
 import uuid
 from datetime import date, datetime
-from typing import Literal
 
 from pydantic import BaseModel
 
-AbsenceType = Literal["holiday", "exchanged_holiday", "illness", "other"]
+
+class AbsenceTypeCreate(BaseModel):
+    name: str
+
+
+class AbsenceTypeUpdate(BaseModel):
+    name: str | None = None
+    is_active: bool | None = None
+
+
+class AbsenceTypeResponse(BaseModel):
+    id: uuid.UUID
+    name: str
+    is_active: bool
+
+    model_config = {"from_attributes": True}
 
 
 class AbsenceCreate(BaseModel):
     record_date: date
-    absence_type: AbsenceType
+    absence_type_id: uuid.UUID
     note: str | None = None
     form_opened_at: datetime  # required for edit window check
 
 
 class AbsenceUpdate(BaseModel):
-    absence_type: AbsenceType | None = None
+    absence_type_id: uuid.UUID | None = None
     note: str | None = None
     form_opened_at: datetime  # required for edit window check
 
@@ -26,7 +40,7 @@ class AbsenceResponse(BaseModel):
     id: uuid.UUID
     user_id: uuid.UUID
     record_date: date
-    absence_type: str
+    absence_type: AbsenceTypeResponse
     note: str | None
     created_at: datetime
 

--- a/backend/app/db/seed.py
+++ b/backend/app/db/seed.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import settings
 from app.core.security import hash_password
+from app.db.models.absence import ABSENCE_TYPE_UUIDS, AbsenceType
 from app.db.models.admin_settings import AdminSettings
 from app.db.models.category import Category, SelfAssessmentTag
 from app.db.models.user import User
@@ -14,6 +15,11 @@ _ADMIN_PASSWORD_DEV_DEFAULT = "ChangeMe_DevOnly!"  # never use in production
 
 async def seed_initial_data(db: AsyncSession):
     """Insert seed data if not already present."""
+    for name, uid in ABSENCE_TYPE_UUIDS.items():
+        existing = await db.execute(select(AbsenceType).where(AbsenceType.name == name))
+        if not existing.scalar_one_or_none():
+            db.add(AbsenceType(id=uid, name=name, is_active=True))
+
     tags = ["OKR", "Routine", "Team Contribution", "Company Contribution"]
     for name in tags:
         existing = await db.execute(

--- a/backend/app/db/seed.py
+++ b/backend/app/db/seed.py
@@ -3,8 +3,13 @@ from uuid import uuid4
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import settings
+from app.core.security import hash_password
 from app.db.models.admin_settings import AdminSettings
 from app.db.models.category import Category, SelfAssessmentTag
+from app.db.models.user import User
+
+_ADMIN_PASSWORD_DEV_DEFAULT = "ChangeMe_DevOnly!"  # never use in production
 
 
 async def seed_initial_data(db: AsyncSession):
@@ -28,5 +33,22 @@ async def seed_initial_data(db: AsyncSession):
     )
     if not existing.scalar_one_or_none():
         db.add(AdminSettings(id=uuid4(), key="output_language", value="ja"))
+
+    if settings.ADMIN_EMAIL:
+        existing_admin = await db.execute(
+            select(User).where(User.email == settings.ADMIN_EMAIL)
+        )
+        if not existing_admin.scalar_one_or_none():
+            raw_password = settings.ADMIN_PASSWORD or _ADMIN_PASSWORD_DEV_DEFAULT
+            db.add(
+                User(
+                    id=uuid4(),
+                    email=settings.ADMIN_EMAIL,
+                    display_name="Admin",
+                    is_admin=True,
+                    allow_local_login=True,
+                    password_hash=hash_password(raw_password),
+                )
+            )
 
     await db.commit()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,13 +9,32 @@ from starlette.types import ExceptionHandler
 
 from app.api.v1 import router as v1_router
 from app.api.v1.social import limiter
+from app.config import settings
 from app.core.scheduler import start_scheduler, stop_scheduler
 from app.db.engine import async_session_factory
 from app.db.seed import seed_initial_data
 
+_WEAK_PASSWORDS = {"admin", "password", "Admin", "Password", "123456", "test", "Test"}
+
+
+def _check_admin_password_strength() -> None:
+    """Refuse to start in non-local environments if ADMIN_PASSWORD is unset or weak."""
+    is_local = (
+        "localhost" in settings.DATABASE_URL or "127.0.0.1" in settings.DATABASE_URL
+    )
+    if is_local:
+        return
+    pwd = settings.ADMIN_PASSWORD
+    if not pwd or pwd in _WEAK_PASSWORDS:
+        raise RuntimeError(
+            "ADMIN_PASSWORD is unset or too weak for a non-local environment. "
+            "Set a strong password via the ADMIN_PASSWORD environment variable."
+        )
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    _check_admin_password_strength()
     async with async_session_factory() as db:
         await seed_initial_data(db)
     start_scheduler()

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -13,6 +13,7 @@ from sqlalchemy.pool import StaticPool
 
 from app.db.engine import get_db
 from app.db.models import Base
+from app.db.models.absence import ABSENCE_TYPE_UUIDS, AbsenceType
 from app.main import app
 
 TEST_DATABASE_URL = "sqlite+aiosqlite:///:memory:"
@@ -37,6 +38,10 @@ async def db_engine():
 async def db_session(db_engine):
     factory = async_sessionmaker(db_engine, expire_on_commit=False)
     async with factory() as session:
+        # Seed absence types with fixed UUIDs so tests can reference them
+        for name, uid in ABSENCE_TYPE_UUIDS.items():
+            session.add(AbsenceType(id=uid, name=name, is_active=True))
+        await session.commit()
         yield session
 
 

--- a/backend/app/tests/test_absences.py
+++ b/backend/app/tests/test_absences.py
@@ -3,7 +3,7 @@
 from datetime import UTC, date, datetime, timedelta
 
 from app.core.security import create_access_token
-from app.db.models.absence import Absence
+from app.db.models.absence import ABSENCE_TYPE_UUIDS, Absence
 from app.db.models.daily_record import DailyRecord
 from app.db.models.team import Team, TeamMembership, TeamSettings
 from app.db.models.user import User
@@ -71,14 +71,14 @@ async def test_create_absence_ok(client, db_session):
         "/api/v1/absences",
         json={
             "record_date": str(date.today()),
-            "absence_type": "holiday",
+            "absence_type_id": str(ABSENCE_TYPE_UUIDS["holiday"]),
             "form_opened_at": now_iso(),
         },
         headers=auth(tok),
     )
     assert resp.status_code == 201
     data = resp.json()
-    assert data["absence_type"] == "holiday"
+    assert data["absence_type"]["name"] == "holiday"
     assert data["user_id"] == str(user.id)
 
 
@@ -106,7 +106,7 @@ async def test_absence_blocked_by_daily_record(client, db_session):
         "/api/v1/absences",
         json={
             "record_date": str(date.today()),
-            "absence_type": "illness",
+            "absence_type_id": str(ABSENCE_TYPE_UUIDS["illness"]),
             "form_opened_at": now_iso(),
         },
         headers=auth(tok),
@@ -129,7 +129,7 @@ async def test_daily_record_blocked_by_absence(client, db_session):
         "/api/v1/absences",
         json={
             "record_date": str(date.today()),
-            "absence_type": "holiday",
+            "absence_type_id": str(ABSENCE_TYPE_UUIDS["holiday"]),
             "form_opened_at": now_iso(),
         },
         headers=auth(tok),
@@ -166,7 +166,7 @@ async def test_duplicate_absence_rejected(client, db_session):
         "/api/v1/absences",
         json={
             "record_date": target_date,
-            "absence_type": "illness",
+            "absence_type_id": str(ABSENCE_TYPE_UUIDS["illness"]),
             "form_opened_at": now_iso(),
         },
         headers=auth(tok),
@@ -177,7 +177,7 @@ async def test_duplicate_absence_rejected(client, db_session):
         "/api/v1/absences",
         json={
             "record_date": target_date,
-            "absence_type": "other",
+            "absence_type_id": str(ABSENCE_TYPE_UUIDS["other"]),
             "form_opened_at": now_iso(),
         },
         headers=auth(tok),
@@ -200,7 +200,7 @@ async def test_list_absences_own(client, db_session):
     absence = Absence(
         user_id=user.id,
         record_date=target_date,
-        absence_type="holiday",
+        absence_type_id=ABSENCE_TYPE_UUIDS["holiday"],
     )
     db_session.add(absence)
     await db_session.commit()
@@ -224,7 +224,9 @@ async def test_list_absences_leader_access(client, db_session):
     await make_membership(db_session, leader.id, team.id)
 
     absence = Absence(
-        user_id=member.id, record_date=date.today(), absence_type="illness"
+        user_id=member.id,
+        record_date=date.today(),
+        absence_type_id=ABSENCE_TYPE_UUIDS["illness"],
     )
     db_session.add(absence)
     await db_session.commit()
@@ -271,7 +273,7 @@ async def test_update_absence(client, db_session):
         "/api/v1/absences",
         json={
             "record_date": str(date.today()),
-            "absence_type": "holiday",
+            "absence_type_id": str(ABSENCE_TYPE_UUIDS["holiday"]),
             "form_opened_at": now_iso(),
         },
         headers=auth(tok),
@@ -281,11 +283,14 @@ async def test_update_absence(client, db_session):
 
     update_resp = await client.put(
         f"/api/v1/absences/{absence_id}",
-        json={"absence_type": "illness", "form_opened_at": now_iso()},
+        json={
+            "absence_type_id": str(ABSENCE_TYPE_UUIDS["illness"]),
+            "form_opened_at": now_iso(),
+        },
         headers=auth(tok),
     )
     assert update_resp.status_code == 200
-    assert update_resp.json()["absence_type"] == "illness"
+    assert update_resp.json()["absence_type"]["name"] == "illness"
 
 
 # ---------------------------------------------------------------------------
@@ -302,7 +307,7 @@ async def test_delete_absence(client, db_session):
         "/api/v1/absences",
         json={
             "record_date": str(date.today()),
-            "absence_type": "other",
+            "absence_type_id": str(ABSENCE_TYPE_UUIDS["other"]),
             "form_opened_at": now_iso(),
         },
         headers=auth(tok),
@@ -342,7 +347,7 @@ async def test_owner_gets_absence_detail(client, db_session):
     absence = Absence(
         user_id=user.id,
         record_date=target_date,
-        absence_type="holiday",
+        absence_type_id=ABSENCE_TYPE_UUIDS["holiday"],
     )
     db_session.add(absence)
     await db_session.commit()
@@ -365,7 +370,7 @@ async def test_leader_gets_team_member_absence_detail(client, db_session):
     absence = Absence(
         user_id=member.id,
         record_date=date.today() - timedelta(days=1),
-        absence_type="illness",
+        absence_type_id=ABSENCE_TYPE_UUIDS["illness"],
     )
     db_session.add(absence)
     await db_session.commit()
@@ -397,7 +402,7 @@ async def test_outsider_cannot_get_absence_detail(client, db_session):
     absence = Absence(
         user_id=owner.id,
         record_date=date.today() - timedelta(days=2),
-        absence_type="other",
+        absence_type_id=ABSENCE_TYPE_UUIDS["other"],
     )
     db_session.add(absence)
     await db_session.commit()
@@ -435,7 +440,7 @@ async def test_missing_days_basic(client, db_session):
     absence = Absence(
         user_id=user.id,
         record_date=last_wednesday,
-        absence_type="holiday",
+        absence_type_id=ABSENCE_TYPE_UUIDS["holiday"],
     )
     db_session.add(absence)
     await db_session.commit()

--- a/backend/app/tests/test_absences.py
+++ b/backend/app/tests/test_absences.py
@@ -463,3 +463,27 @@ async def test_missing_days_basic(client, db_session):
     last_thursday = last_monday + timedelta(days=3)
     assert str(last_thursday) in missing
     assert str(last_friday) in missing
+
+
+# ---------------------------------------------------------------------------
+# 15. POST /absences with unknown absence_type_id → 422
+# ---------------------------------------------------------------------------
+
+
+async def test_create_absence_unknown_type_id_422(client, db_session):
+    import uuid
+
+    user, tok = await make_user(db_session, "abs15@t.com")
+    team = await make_team(db_session, "abs15_team")
+    await make_membership(db_session, user.id, team.id)
+
+    resp = await client.post(
+        "/api/v1/absences",
+        json={
+            "record_date": str(date.today()),
+            "absence_type_id": str(uuid.uuid4()),  # random, non-existent UUID
+            "form_opened_at": now_iso(),
+        },
+        headers=auth(tok),
+    )
+    assert resp.status_code == 422

--- a/backend/app/tests/test_auth.py
+++ b/backend/app/tests/test_auth.py
@@ -251,3 +251,89 @@ async def test_patch_me_invalid_locale(client, mocker):
 async def test_patch_me_no_token(client):
     resp = await client.patch("/api/v1/users/me", json={"display_name": "X"})
     assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Local login tests
+# ---------------------------------------------------------------------------
+
+
+async def _create_local_user(
+    db_session,
+    email: str,
+    password: str,
+    *,
+    allow_local_login: bool = True,
+    is_admin: bool = False,
+) -> None:
+    from uuid import uuid4
+
+    from app.core.security import hash_password
+    from app.db.models.user import User
+
+    user = User(
+        id=uuid4(),
+        email=email,
+        display_name="Test",
+        is_admin=is_admin,
+        allow_local_login=allow_local_login,
+        password_hash=hash_password(password),
+    )
+    db_session.add(user)
+    await db_session.commit()
+
+
+async def test_local_login_success(client, db_session):
+    await _create_local_user(
+        db_session, "local-ok@example.com", "GoodPass1!", is_admin=True
+    )
+
+    resp = await client.post(
+        "/api/v1/auth/local-login",
+        json={"email": "local-ok@example.com", "password": "GoodPass1!"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "access_token" in data
+    assert data["token_type"] == "bearer"
+
+    # Token must work on /me
+    resp2 = await client.get(
+        "/api/v1/auth/me",
+        headers={"Authorization": f"Bearer {data['access_token']}"},
+    )
+    assert resp2.status_code == 200
+    assert resp2.json()["email"] == "local-ok@example.com"
+
+
+async def test_local_login_wrong_password(client, db_session):
+    await _create_local_user(db_session, "local-wp@example.com", "CorrectPass1!")
+
+    resp = await client.post(
+        "/api/v1/auth/local-login",
+        json={"email": "local-wp@example.com", "password": "WrongPass!"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"
+
+
+async def test_local_login_account_not_allowed(client, db_session):
+    await _create_local_user(
+        db_session, "sso-only@example.com", "AnyPass1!", allow_local_login=False
+    )
+
+    resp = await client.post(
+        "/api/v1/auth/local-login",
+        json={"email": "sso-only@example.com", "password": "AnyPass1!"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"
+
+
+async def test_local_login_nonexistent_user(client):
+    resp = await client.post(
+        "/api/v1/auth/local-login",
+        json={"email": "nobody@example.com", "password": "DoesntMatter!"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["detail"] == "Invalid credentials"

--- a/backend/app/tests/test_controlled_lists.py
+++ b/backend/app/tests/test_controlled_lists.py
@@ -373,3 +373,120 @@ async def test_non_admin_cannot_create_self_assessment_tag(client, db_session):
         "/api/v1/self-assessment-tags", json={"name": "cl13_Tag"}, headers=auth(tok)
     )
     assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 14. Admin creates absence type → 201
+# ---------------------------------------------------------------------------
+
+
+async def test_absence_type_admin_create_ok(client, db_session):
+    admin, tok = await make_user(db_session, "cl14_admin@t.com", is_admin=True)
+    team = await make_team(db_session, "cl14_Team")
+    await make_membership(db_session, admin.id, team.id)
+
+    resp = await client.post(
+        "/api/v1/absence-types", json={"name": "Bereavement"}, headers=auth(tok)
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Bereavement"
+    assert data["is_active"] is True
+    assert "id" in data
+
+
+# ---------------------------------------------------------------------------
+# 15. Non-admin cannot create absence type → 403
+# ---------------------------------------------------------------------------
+
+
+async def test_absence_type_non_admin_denied(client, db_session):
+    member, tok = await make_user(db_session, "cl15_member@t.com")
+    team = await make_team(db_session, "cl15_Team")
+    await make_membership(db_session, member.id, team.id)
+
+    resp = await client.post(
+        "/api/v1/absence-types", json={"name": "Bereavement"}, headers=auth(tok)
+    )
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 16. GET absence types returns active only by default
+# ---------------------------------------------------------------------------
+
+
+async def test_absence_type_list_active_only(client, db_session):
+    admin, tok = await make_user(db_session, "cl16_admin@t.com", is_admin=True)
+    team = await make_team(db_session, "cl16_Team")
+    await make_membership(db_session, admin.id, team.id)
+
+    from app.db.models.absence import AbsenceType
+
+    db_session.add(AbsenceType(id=uuid4(), name="cl16_Active", is_active=True))
+    db_session.add(AbsenceType(id=uuid4(), name="cl16_Inactive", is_active=False))
+    await db_session.commit()
+
+    resp = await client.get("/api/v1/absence-types", headers=auth(tok))
+    assert resp.status_code == 200
+    names = [at["name"] for at in resp.json()]
+    assert "cl16_Active" in names
+    assert "cl16_Inactive" not in names
+
+
+# ---------------------------------------------------------------------------
+# 17. GET absence types with include_inactive=true (admin) returns all
+# ---------------------------------------------------------------------------
+
+
+async def test_absence_type_list_include_inactive_admin(client, db_session):
+    admin, tok = await make_user(db_session, "cl17_admin@t.com", is_admin=True)
+    team = await make_team(db_session, "cl17_Team")
+    await make_membership(db_session, admin.id, team.id)
+
+    from app.db.models.absence import AbsenceType
+
+    db_session.add(AbsenceType(id=uuid4(), name="cl17_Active", is_active=True))
+    db_session.add(AbsenceType(id=uuid4(), name="cl17_Inactive", is_active=False))
+    await db_session.commit()
+
+    resp = await client.get(
+        "/api/v1/absence-types?include_inactive=true", headers=auth(tok)
+    )
+    assert resp.status_code == 200
+    names = [at["name"] for at in resp.json()]
+    assert "cl17_Active" in names
+    assert "cl17_Inactive" in names
+
+
+# ---------------------------------------------------------------------------
+# 18. Admin patches absence type name and is_active
+# ---------------------------------------------------------------------------
+
+
+async def test_absence_type_patch_name_and_is_active(client, db_session):
+    admin, tok = await make_user(db_session, "cl18_admin@t.com", is_admin=True)
+    team = await make_team(db_session, "cl18_Team")
+    await make_membership(db_session, admin.id, team.id)
+
+    create_resp = await client.post(
+        "/api/v1/absence-types",
+        json={"name": "cl18_Original"},
+        headers=auth(tok),
+    )
+    assert create_resp.status_code == 201
+    at_id = create_resp.json()["id"]
+
+    patch_resp = await client.patch(
+        f"/api/v1/absence-types/{at_id}",
+        json={"name": "cl18_Renamed", "is_active": False},
+        headers=auth(tok),
+    )
+    assert patch_resp.status_code == 200
+    data = patch_resp.json()
+    assert data["name"] == "cl18_Renamed"
+    assert data["is_active"] is False
+
+    list_resp = await client.get("/api/v1/absence-types", headers=auth(tok))
+    names = [at["name"] for at in list_resp.json()]
+    assert "cl18_Renamed" not in names  # hidden from active-only list

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -30,6 +30,7 @@ dev = [
     "aiosqlite>=0.20",
     "ruff>=0.15.9",
     "pyright>=1.1.408",
+    "mypy>=1.20.1",
 ]
 
 [tool.pytest.ini_options]

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "slowapi>=0.1.9",
     "limits>=3.13",
     "websockets>=12.0",
+    "bcrypt>=4.2",
 ]
 
 [dependency-groups]

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+# Frontend environment variables — copy to .env.local and fill in values
+
+# Set to "true" to show the "Admin login" link on the login page.
+# Enable only for local development or in recovery scenarios.
+# Never enable in production for regular users.
+VITE_ENABLE_LOCAL_LOGIN=false

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { ThemeProvider } from './context/ThemeContext';
 import { ProtectedRoute } from './routes/ProtectedRoute';
 import { AppShell } from './components/layout/AppShell';
 import { LoginPage } from './pages/LoginPage';
+import { LocalLoginPage } from './pages/LocalLoginPage';
 import { OnboardingPage } from './pages/OnboardingPage';
 import { DashboardPage } from './pages/DashboardPage';
 import { DailyFormPage } from './pages/DailyFormPage';
@@ -33,6 +34,7 @@ function App() {
     <BrowserRouter>
       <Routes>
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/admin-login" element={<LocalLoginPage />} />
         <Route path="/onboarding" element={<ProtectedRoute allowLobby><OnboardingPage /></ProtectedRoute>} />
         <Route path="/" element={<ProtectedRoute><AppShell /></ProtectedRoute>}>
           <Route index element={<DashboardPage />} />

--- a/frontend/src/api/absenceTypes.ts
+++ b/frontend/src/api/absenceTypes.ts
@@ -1,0 +1,22 @@
+import client from './client';
+import type { AbsenceType } from '../types/dailyRecord';
+
+export async function getAbsenceTypes(includeInactive = false): Promise<AbsenceType[]> {
+  const res = await client.get<AbsenceType[]>('/absence-types', {
+    params: includeInactive ? { include_inactive: true } : {},
+  });
+  return res.data;
+}
+
+export async function createAbsenceType(payload: { name: string }): Promise<AbsenceType> {
+  const res = await client.post<AbsenceType>('/absence-types', payload);
+  return res.data;
+}
+
+export async function updateAbsenceType(
+  id: string,
+  payload: { name?: string; is_active?: boolean }
+): Promise<AbsenceType> {
+  const res = await client.patch<AbsenceType>(`/absence-types/${id}`, payload);
+  return res.data;
+}

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -5,4 +5,6 @@ export const authApi = {
   me: () => client.get<User>('/auth/me'),
   logout: () => client.post('/auth/logout'),
   getLoginUrl: () => '/api/v1/auth/login',
+  localLogin: (email: string, password: string) =>
+    client.post<{ access_token: string }>('/auth/local-login', { email, password }),
 };

--- a/frontend/src/api/dailyRecords.ts
+++ b/frontend/src/api/dailyRecords.ts
@@ -54,7 +54,7 @@ export async function getDailyRecords(params: {
 
 export async function createAbsence(payload: {
   record_date: string;
-  absence_type: string;
+  absence_type_id: string;
   note?: string | null;
   form_opened_at: string;
 }): Promise<Absence> {
@@ -74,7 +74,7 @@ export async function deleteAbsence(
 export async function updateAbsence(
   id: string,
   payload: {
-    absence_type?: string;
+    absence_type_id?: string;
     note?: string | null;
     form_opened_at: string;
   }

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -12,7 +12,8 @@
   "auth": {
     "signIn": "Sign in with Microsoft",
     "signOut": "Sign out",
-    "signingIn": "Signing in..."
+    "signingIn": "Signing in...",
+    "adminLogin": "Admin login"
   },
   "onboarding": {
     "title": "Join a Team",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -35,5 +35,57 @@
     "saving": "Saving…",
     "saved": "Saved ✓",
     "saveError": "Save failed. Please try again."
+  },
+  "adminLists": {
+    "pageTitle": "Controlled Lists (Admin)",
+    "back": "← Back",
+    "unsavedWarning": "You have unsaved changes. Leave anyway?",
+    "loading": "Loading…",
+    "confirm": {
+      "message": "Deactivating will hide this category from new forms. Historical records are unaffected.",
+      "cancel": "Cancel",
+      "confirm": "Confirm"
+    },
+    "categories": {
+      "title": "Categories",
+      "colName": "Name",
+      "colSubTypes": "Sub-types",
+      "colActive": "Active",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "newSubTypePlaceholder": "New sub-type",
+      "addSubType": "Add",
+      "newCategoryPlaceholder": "New category name",
+      "addCategory": "Add Category",
+      "loading": "Loading categories…"
+    },
+    "blockerTypes": {
+      "title": "Blocker Types",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "newPlaceholder": "New blocker type",
+      "add": "Add"
+    },
+    "tags": {
+      "title": "Self-Assessment Tags",
+      "save": "Save",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "newPlaceholder": "New tag name",
+      "add": "Add Tag"
+    },
+    "settings": {
+      "title": "Global Settings",
+      "outputLanguageLabel": "Output Language",
+      "saving": "Saving…",
+      "description": "Applies to weekly emails and quarterly reports. UI language is set per user."
+    },
+    "absenceTypes": {
+      "title": "Absence Types",
+      "deactivate": "Deactivate",
+      "activate": "Activate",
+      "newPlaceholder": "New absence type",
+      "add": "Add"
+    }
   }
 }

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -12,7 +12,8 @@
   "auth": {
     "signIn": "Microsoftでサインイン",
     "signOut": "サインアウト",
-    "signingIn": "サインイン中..."
+    "signingIn": "サインイン中...",
+    "adminLogin": "管理者ログイン"
   },
   "onboarding": {
     "title": "チームに参加",

--- a/frontend/src/i18n/ja.json
+++ b/frontend/src/i18n/ja.json
@@ -35,5 +35,57 @@
     "saving": "保存中…",
     "saved": "保存しました ✓",
     "saveError": "保存に失敗しました。もう一度お試しください。"
+  },
+  "adminLists": {
+    "pageTitle": "管理リスト（管理者）",
+    "back": "← 戻る",
+    "unsavedWarning": "未保存の変更があります。このまま離れますか？",
+    "loading": "読み込み中…",
+    "confirm": {
+      "message": "無効化すると、このカテゴリは新規入力フォームに表示されなくなります。過去の記録には影響しません。",
+      "cancel": "キャンセル",
+      "confirm": "確認"
+    },
+    "categories": {
+      "title": "カテゴリ",
+      "colName": "名前",
+      "colSubTypes": "サブタイプ",
+      "colActive": "有効",
+      "deactivate": "無効化",
+      "activate": "有効化",
+      "newSubTypePlaceholder": "新しいサブタイプ",
+      "addSubType": "追加",
+      "newCategoryPlaceholder": "新しいカテゴリ名",
+      "addCategory": "カテゴリを追加",
+      "loading": "カテゴリを読み込み中…"
+    },
+    "blockerTypes": {
+      "title": "ブロッカータイプ",
+      "deactivate": "無効化",
+      "activate": "有効化",
+      "newPlaceholder": "新しいブロッカータイプ",
+      "add": "追加"
+    },
+    "tags": {
+      "title": "自己評価タグ",
+      "save": "保存",
+      "deactivate": "無効化",
+      "activate": "有効化",
+      "newPlaceholder": "新しいタグ名",
+      "add": "タグを追加"
+    },
+    "settings": {
+      "title": "グローバル設定",
+      "outputLanguageLabel": "出力言語",
+      "saving": "保存中…",
+      "description": "週次メールおよび四半期レポートに適用されます。UI言語はユーザーごとに設定されます。"
+    },
+    "absenceTypes": {
+      "title": "欠勤タイプ",
+      "deactivate": "無効化",
+      "activate": "有効化",
+      "newPlaceholder": "新しい欠勤タイプ",
+      "add": "追加"
+    }
   }
 }

--- a/frontend/src/i18n/ko.json
+++ b/frontend/src/i18n/ko.json
@@ -12,7 +12,8 @@
   "auth": {
     "signIn": "Microsoft로 로그인",
     "signOut": "로그아웃",
-    "signingIn": "로그인 중..."
+    "signingIn": "로그인 중...",
+    "adminLogin": "관리자 로그인"
   },
   "onboarding": {
     "title": "팀 참가",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -12,7 +12,8 @@
   "auth": {
     "signIn": "使用Microsoft登录",
     "signOut": "退出登录",
-    "signingIn": "登录中..."
+    "signingIn": "登录中...",
+    "adminLogin": "管理员登录"
   },
   "onboarding": {
     "title": "加入团队",

--- a/frontend/src/pages/AdminListsPage.tsx
+++ b/frontend/src/pages/AdminListsPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import {
   getCategories,
@@ -16,6 +17,12 @@ import {
 import { getAdminSettings, updateAdminSettings } from '../api/adminSettings';
 import type { AdminSettingsData } from '../api/adminSettings';
 import type { Category, BlockerType, SelfAssessmentTag } from '../types/dailyRecord';
+import {
+  getAbsenceTypes,
+  createAbsenceType,
+  updateAbsenceType,
+} from '../api/absenceTypes';
+import type { AbsenceType } from '../types/dailyRecord';
 
 // ---------------------------------------------------------------------------
 // Confirmation dialog helper (inline, no library)
@@ -30,6 +37,7 @@ function ConfirmDialog({
   onConfirm: () => void;
   onCancel: () => void;
 }) {
+  const { t } = useTranslation();
   return (
     <div
       style={{
@@ -45,8 +53,8 @@ function ConfirmDialog({
       <div style={{ background: 'var(--bg)', borderRadius: '8px', padding: '1.5rem', maxWidth: '400px' }}>
         <p style={{ margin: '0 0 1rem' }}>{message}</p>
         <div style={{ display: 'flex', gap: '0.5rem', justifyContent: 'flex-end' }}>
-          <button onClick={onCancel} style={cancelBtn}>Cancel</button>
-          <button onClick={onConfirm} style={dangerBtn}>Confirm</button>
+          <button onClick={onCancel} style={cancelBtn}>{t('adminLists.confirm.cancel')}</button>
+          <button onClick={onConfirm} style={dangerBtn}>{t('adminLists.confirm.confirm')}</button>
         </div>
       </div>
     </div>
@@ -58,6 +66,7 @@ function ConfirmDialog({
 // ---------------------------------------------------------------------------
 
 function CategoriesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }) {
+  const { t } = useTranslation();
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
   const [newCatName, setNewCatName] = useState('');
@@ -109,24 +118,24 @@ function CategoriesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) 
     reload();
   };
 
-  if (loading) return <p>Loading categories…</p>;
+  if (loading) return <p>{t('adminLists.categories.loading')}</p>;
 
   return (
     <section style={sectionStyle}>
       {confirm && (
         <ConfirmDialog
-          message="Deactivating will hide this category from new forms. Historical records are unaffected."
+          message={t('adminLists.confirm.message')}
           onConfirm={confirmDeactivate}
           onCancel={() => setConfirm(null)}
         />
       )}
-      <h3 style={sectionTitle}>Categories</h3>
+      <h3 style={sectionTitle}>{t('adminLists.categories.title')}</h3>
       <table style={tableStyle}>
         <thead>
           <tr>
-            <th style={th}>Name</th>
-            <th style={th}>Sub-types</th>
-            <th style={th}>Active</th>
+            <th style={th}>{t('adminLists.categories.colName')}</th>
+            <th style={th}>{t('adminLists.categories.colSubTypes')}</th>
+            <th style={th}>{t('adminLists.categories.colActive')}</th>
           </tr>
         </thead>
         <tbody>
@@ -142,7 +151,7 @@ function CategoriesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) 
                         style={tinyBtn}
                         onClick={() => toggleSubActive(st.id, st.is_active)}
                       >
-                        {st.is_active ? 'Deactivate' : 'Activate'}
+                        {st.is_active ? t('adminLists.categories.deactivate') : t('adminLists.categories.activate')}
                       </button>
                     </li>
                   ))}
@@ -150,18 +159,18 @@ function CategoriesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) 
                 <div style={{ display: 'flex', gap: '0.3rem', marginTop: '0.3rem' }}>
                   <input
                     style={smallInput}
-                    placeholder="New sub-type"
+                    placeholder={t('adminLists.categories.newSubTypePlaceholder')}
                     value={newSubNames[cat.id] ?? ''}
                     onChange={(e) =>
                       setNewSubNames((prev) => ({ ...prev, [cat.id]: e.target.value }))
                     }
                   />
-                  <button style={tinyBtn} onClick={() => addSubType(cat.id)}>Add</button>
+                  <button style={tinyBtn} onClick={() => addSubType(cat.id)}>{t('adminLists.categories.addSubType')}</button>
                 </div>
               </td>
               <td style={td}>
                 <button style={tinyBtn} onClick={() => toggleActive(cat)}>
-                  {cat.is_active ? 'Deactivate' : 'Activate'}
+                  {cat.is_active ? t('adminLists.categories.deactivate') : t('adminLists.categories.activate')}
                 </button>
               </td>
             </tr>
@@ -171,12 +180,12 @@ function CategoriesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) 
       <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
         <input
           style={inputStyle}
-          placeholder="New category name"
+          placeholder={t('adminLists.categories.newCategoryPlaceholder')}
           value={newCatName}
           onChange={(e) => { setNewCatName(e.target.value); onDirtyChange(!!e.target.value.trim()); }}
           onKeyDown={(e) => e.key === 'Enter' && addCategory()}
         />
-        <button style={primaryBtn} onClick={addCategory}>Add Category</button>
+        <button style={primaryBtn} onClick={addCategory}>{t('adminLists.categories.addCategory')}</button>
       </div>
     </section>
   );
@@ -187,6 +196,7 @@ function CategoriesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) 
 // ---------------------------------------------------------------------------
 
 function BlockerTypesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }) {
+  const { t } = useTranslation();
   const [types, setTypes] = useState<BlockerType[]>([]);
   const [loading, setLoading] = useState(true);
   const [newName, setNewName] = useState('');
@@ -210,11 +220,11 @@ function BlockerTypesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean
     reload();
   };
 
-  if (loading) return <p>Loading…</p>;
+  if (loading) return <p>{t('adminLists.loading')}</p>;
 
   return (
     <section style={sectionStyle}>
-      <h3 style={sectionTitle}>Blocker Types</h3>
+      <h3 style={sectionTitle}>{t('adminLists.blockerTypes.title')}</h3>
       <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
         {types.map((bt) => (
           <li
@@ -230,7 +240,7 @@ function BlockerTypesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean
           >
             <span style={{ flex: 1 }}>{bt.name}</span>
             <button style={tinyBtn} onClick={() => toggle(bt)}>
-              {bt.is_active ? 'Deactivate' : 'Activate'}
+              {bt.is_active ? t('adminLists.blockerTypes.deactivate') : t('adminLists.blockerTypes.activate')}
             </button>
           </li>
         ))}
@@ -238,12 +248,12 @@ function BlockerTypesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean
       <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
         <input
           style={inputStyle}
-          placeholder="New blocker type"
+          placeholder={t('adminLists.blockerTypes.newPlaceholder')}
           value={newName}
           onChange={(e) => { setNewName(e.target.value); onDirtyChange(!!e.target.value.trim()); }}
           onKeyDown={(e) => e.key === 'Enter' && add()}
         />
-        <button style={primaryBtn} onClick={add}>Add</button>
+        <button style={primaryBtn} onClick={add}>{t('adminLists.blockerTypes.add')}</button>
       </div>
     </section>
   );
@@ -254,6 +264,7 @@ function BlockerTypesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean
 // ---------------------------------------------------------------------------
 
 function TagsSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }) {
+  const { t } = useTranslation();
   const [tags, setTags] = useState<SelfAssessmentTag[]>([]);
   const [loading, setLoading] = useState(true);
   const [editNames, setEditNames] = useState<Record<string, string>>({});
@@ -283,11 +294,11 @@ function TagsSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => voi
     reload();
   };
 
-  if (loading) return <p>Loading…</p>;
+  if (loading) return <p>{t('adminLists.loading')}</p>;
 
   return (
     <section style={sectionStyle}>
-      <h3 style={sectionTitle}>Self-Assessment Tags</h3>
+      <h3 style={sectionTitle}>{t('adminLists.tags.title')}</h3>
       <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
         {tags.map((tag) => (
           <li
@@ -300,9 +311,9 @@ function TagsSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => voi
               value={editNames[tag.id] ?? tag.name}
               onChange={(e) => setEditNames((prev) => ({ ...prev, [tag.id]: e.target.value }))}
             />
-            <button style={tinyBtn} onClick={() => save(tag)}>Save</button>
+            <button style={tinyBtn} onClick={() => save(tag)}>{t('adminLists.tags.save')}</button>
             <button style={tinyBtn} onClick={() => toggle(tag)}>
-              {tag.is_active ? 'Deactivate' : 'Activate'}
+              {tag.is_active ? t('adminLists.tags.deactivate') : t('adminLists.tags.activate')}
             </button>
           </li>
         ))}
@@ -310,12 +321,79 @@ function TagsSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => voi
       <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
         <input
           style={inputStyle}
-          placeholder="New tag name"
+          placeholder={t('adminLists.tags.newPlaceholder')}
           value={newTagName}
           onChange={(e) => { setNewTagName(e.target.value); onDirtyChange(!!e.target.value.trim()); }}
           onKeyDown={(e) => e.key === 'Enter' && add()}
         />
-        <button style={primaryBtn} onClick={add}>Add Tag</button>
+        <button style={primaryBtn} onClick={add}>{t('adminLists.tags.add')}</button>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Absence types section
+// ---------------------------------------------------------------------------
+
+function AbsenceTypesSection({ onDirtyChange }: { onDirtyChange: (dirty: boolean) => void }) {
+  const { t } = useTranslation();
+  const [types, setTypes] = useState<AbsenceType[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newName, setNewName] = useState('');
+
+  const reload = () =>
+    getAbsenceTypes(true).then(setTypes).finally(() => setLoading(false));
+
+  useEffect(() => { reload(); }, []);
+
+  const add = async () => {
+    const name = newName.trim();
+    if (!name) return;
+    await createAbsenceType({ name });
+    setNewName('');
+    reload();
+  };
+
+  const toggle = async (at: AbsenceType) => {
+    await updateAbsenceType(at.id, { is_active: !at.is_active });
+    reload();
+  };
+
+  if (loading) return <p>{t('adminLists.loading')}</p>;
+
+  return (
+    <section style={sectionStyle}>
+      <h3 style={sectionTitle}>{t('adminLists.absenceTypes.title')}</h3>
+      <ul style={{ margin: 0, padding: 0, listStyle: 'none' }}>
+        {types.map((at) => (
+          <li
+            key={at.id}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '0.75rem',
+              padding: '0.35rem 0',
+              borderBottom: '1px solid var(--border-subtle)',
+              opacity: at.is_active ? 1 : 0.5,
+            }}
+          >
+            <span style={{ flex: 1 }}>{at.name}</span>
+            <button style={tinyBtn} onClick={() => toggle(at)}>
+              {at.is_active ? t('adminLists.absenceTypes.deactivate') : t('adminLists.absenceTypes.activate')}
+            </button>
+          </li>
+        ))}
+      </ul>
+      <div style={{ display: 'flex', gap: '0.5rem', marginTop: '1rem' }}>
+        <input
+          style={inputStyle}
+          placeholder={t('adminLists.absenceTypes.newPlaceholder')}
+          value={newName}
+          onChange={(e) => { setNewName(e.target.value); onDirtyChange(!!e.target.value.trim()); }}
+          onKeyDown={(e) => e.key === 'Enter' && add()}
+        />
+        <button style={primaryBtn} onClick={add}>{t('adminLists.absenceTypes.add')}</button>
       </div>
     </section>
   );
@@ -333,6 +411,7 @@ const LANGUAGE_OPTIONS: { value: string; label: string }[] = [
 ];
 
 function AdminSettingsSection() {
+  const { t } = useTranslation();
   const [settings, setSettings] = useState<AdminSettingsData | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -354,13 +433,13 @@ function AdminSettingsSection() {
     }
   };
 
-  if (loading) return <p>Loading…</p>;
+  if (loading) return <p>{t('adminLists.loading')}</p>;
 
   return (
     <section style={sectionStyle}>
-      <h3 style={sectionTitle}>Global Settings</h3>
+      <h3 style={sectionTitle}>{t('adminLists.settings.title')}</h3>
       <div style={{ display: 'flex', alignItems: 'center', gap: '1rem' }}>
-        <label style={{ fontWeight: 500, fontSize: '0.9rem' }}>Output Language</label>
+        <label style={{ fontWeight: 500, fontSize: '0.9rem' }}>{t('adminLists.settings.outputLanguageLabel')}</label>
         <select
           disabled={saving}
           value={settings?.output_language ?? ''}
@@ -378,10 +457,10 @@ function AdminSettingsSection() {
             <option key={opt.value} value={opt.value}>{opt.label}</option>
           ))}
         </select>
-        {saving && <span style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>Saving…</span>}
+        {saving && <span style={{ fontSize: '0.8rem', color: 'var(--text-muted)' }}>{t('adminLists.settings.saving')}</span>}
       </div>
       <p style={{ margin: '0.5rem 0 0', fontSize: '0.8rem', color: 'var(--text-muted)' }}>
-        Applies to weekly emails and quarterly reports. UI language is set per user.
+        {t('adminLists.settings.description')}
       </p>
     </section>
   );
@@ -392,14 +471,16 @@ function AdminSettingsSection() {
 // ---------------------------------------------------------------------------
 
 export const AdminListsPage = () => {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [catDirty, setCatDirty] = useState(false);
   const [blockerDirty, setBlockerDirty] = useState(false);
   const [tagDirty, setTagDirty] = useState(false);
-  const isDirty = catDirty || blockerDirty || tagDirty;
+  const [absenceDirty, setAbsenceDirty] = useState(false);
+  const isDirty = catDirty || blockerDirty || tagDirty || absenceDirty;
 
   const handleBack = () => {
-    if (isDirty && !window.confirm('You have unsaved changes. Leave anyway?')) return;
+    if (isDirty && !window.confirm(t('adminLists.unsavedWarning'))) return;
     navigate('/');
   };
 
@@ -409,12 +490,13 @@ export const AdminListsPage = () => {
         onClick={handleBack}
         style={{ background: 'none', border: 'none', color: 'var(--primary)', cursor: 'pointer', padding: 0, fontSize: '0.85rem', marginBottom: '1rem', display: 'block' }}
       >
-        ← Back
+        {t('adminLists.back')}
       </button>
-      <h2 style={{ marginBottom: '1rem' }}>Controlled Lists (Admin)</h2>
+      <h2 style={{ marginBottom: '1rem' }}>{t('adminLists.pageTitle')}</h2>
       <AdminSettingsSection />
       <CategoriesSection onDirtyChange={setCatDirty} />
       <BlockerTypesSection onDirtyChange={setBlockerDirty} />
+      <AbsenceTypesSection onDirtyChange={setAbsenceDirty} />
       <TagsSection onDirtyChange={setTagDirty} />
     </div>
   );

--- a/frontend/src/pages/DailyFormPage.tsx
+++ b/frontend/src/pages/DailyFormPage.tsx
@@ -11,10 +11,12 @@ import {
 } from '../api/dailyRecords';
 import { getActiveTasks, getTask } from '../api/tasks';
 import { getCategories, getSelfAssessmentTags, getBlockerTypes } from '../api/categories';
+import { getAbsenceTypes } from '../api/absenceTypes';
 import { getProjects } from '../api/projects';
 import { WorkLogRow } from '../components/tasks/WorkLogRow';
 import { TaskCreateModal } from '../components/tasks/TaskCreateModal';
 import type {
+  AbsenceType,
   Category,
   SelfAssessmentTag,
   BlockerType,
@@ -144,6 +146,7 @@ export const DailyFormPage = () => {
   const [tags, setTags] = useState<SelfAssessmentTag[]>([]);
   const [blockerTypes, setBlockerTypes] = useState<BlockerType[]>([]);
   const [projects, setProjects] = useState<Project[]>([]);
+  const [absenceTypes, setAbsenceTypes] = useState<AbsenceType[]>([]);
 
   // Record state
   const [existingRecord, setExistingRecord] = useState<DailyRecord | null>(null);
@@ -189,7 +192,8 @@ export const DailyFormPage = () => {
     setExistingAbsence(null);
     setUnlockGrant(null);
     setIsAbsenceMode(false);
-    setAbsenceType('holiday');
+    setAbsenceTypes([]);
+    setAbsenceType('');
     setWorkLogs([]);
     setDayLoad(3);
     setDayNote('');
@@ -199,12 +203,13 @@ export const DailyFormPage = () => {
     isDirty.current = false;
     (async () => {
       try {
-        const [cats, tagList, btList, projs, records, absences, grants, activeTasks] =
+        const [cats, tagList, btList, projs, absenceTypeList, records, absences, grants, activeTasks] =
           await Promise.all([
             getCategories(),
             getSelfAssessmentTags(),
             getBlockerTypes(),
             getProjects(),
+            getAbsenceTypes(),
             getDailyRecords({ date: recordDate }),
             getAbsences({ start_date: recordDate, end_date: recordDate }),
             getUnlockGrants({ record_date: recordDate }),
@@ -214,6 +219,8 @@ export const DailyFormPage = () => {
         setTags(tagList);
         setBlockerTypes(btList);
         setProjects(projs);
+        setAbsenceTypes(absenceTypeList);
+        setAbsenceType(absenceTypeList[0]?.id ?? '');
 
         if (records.length > 0) {
           const rec = records[0];
@@ -272,7 +279,7 @@ export const DailyFormPage = () => {
         if (absences.length > 0) {
           setExistingAbsence(absences[0]);
           setIsAbsenceMode(true);
-          setAbsenceType(absences[0].absence_type);
+          setAbsenceType(absences[0].absence_type.id);
         }
 
         const activeGrant = grants.find((g) => g.revoked_at === null);
@@ -393,7 +400,7 @@ export const DailyFormPage = () => {
     try {
       const abs = await createAbsence({
         record_date: recordDate,
-        absence_type: absenceType,
+        absence_type_id: absenceType,
         form_opened_at: formOpenedAt.current.toISOString(),
       });
       setExistingAbsence(abs);
@@ -564,10 +571,9 @@ export const DailyFormPage = () => {
               onChange={(e) => setAbsenceType(e.target.value)}
               style={{ ...s.select, marginLeft: '0.75rem', width: 'auto' }}
             >
-              <option value="holiday">Public Holiday</option>
-              <option value="exchanged_holiday">Exchanged Holiday</option>
-              <option value="illness">Illness</option>
-              <option value="other">Other</option>
+              {absenceTypes.map((t) => (
+                <option key={t.id} value={t.id}>{t.name}</option>
+              ))}
             </select>
             <button
               type="button"
@@ -581,7 +587,7 @@ export const DailyFormPage = () => {
         )}
         {existingAbsence && (
           <span style={{ marginLeft: '0.75rem', color: 'var(--text-secondary)' }}>
-            Type: {existingAbsence.absence_type.replace('_', ' ')}
+            Type: {existingAbsence.absence_type.name}
           </span>
         )}
       </div>
@@ -784,7 +790,7 @@ export const DailyFormPage = () => {
         <div style={s.absenceSummary}>
           <p>
             This day is recorded as an absence (
-            <strong>{existingAbsence.absence_type.replace('_', ' ')}</strong>).
+            <strong>{existingAbsence.absence_type.name}</strong>).
           </p>
           {isEditable && (
             <button

--- a/frontend/src/pages/LocalLoginPage.tsx
+++ b/frontend/src/pages/LocalLoginPage.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import type { SyntheticEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { authApi } from '../api/auth';
+import { useAuth } from '../hooks/useAuth';
+
+export const LocalLoginPage = () => {
+  const { setToken, fetchMe } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleSubmit = async (e: SyntheticEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      const res = await authApi.localLogin(email, password);
+      setToken(res.data.access_token);
+      await fetchMe();
+      navigate('/', { replace: true });
+    } catch (err: unknown) {
+      const status =
+        (err as { response?: { status?: number } })?.response?.status;
+      if (status === 429) {
+        setError('Too many attempts. Please try again later.');
+      } else {
+        setError('Invalid email or password.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        height: '100vh',
+        flexDirection: 'column',
+        gap: '1.5rem',
+      }}
+    >
+      <h1 style={{ fontSize: '2rem', fontWeight: 700 }}>TeamTakt</h1>
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: 'flex', flexDirection: 'column', gap: '0.75rem', width: '280px' }}
+      >
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}>
+          Email
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+            autoComplete="username"
+            style={{ padding: '0.5rem', border: '1px solid var(--border)', borderRadius: '4px', fontSize: '1rem' }}
+          />
+        </label>
+        <label style={{ display: 'flex', flexDirection: 'column', gap: '0.25rem', fontSize: '0.875rem' }}>
+          Password
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            autoComplete="current-password"
+            style={{ padding: '0.5rem', border: '1px solid var(--border)', borderRadius: '4px', fontSize: '1rem' }}
+          />
+        </label>
+        {error && (
+          <p role="alert" style={{ color: 'var(--error, #c0392b)', margin: 0, fontSize: '0.875rem' }}>
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={loading}
+          style={{
+            padding: '0.75rem',
+            background: 'var(--primary)',
+            color: '#fff',
+            border: 'none',
+            borderRadius: '6px',
+            fontSize: '1rem',
+            cursor: loading ? 'not-allowed' : 'pointer',
+            opacity: loading ? 0.7 : 1,
+          }}
+        >
+          {loading ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+    </div>
+  );
+};

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../hooks/useAuth';
 import { authApi } from '../api/auth';
@@ -42,6 +42,14 @@ export const LoginPage = () => {
       >
         {t('auth.signIn')}
       </button>
+      {import.meta.env.VITE_ENABLE_LOCAL_LOGIN === 'true' && (
+        <Link
+          to="/admin-login"
+          style={{ fontSize: '0.8rem', color: 'var(--text-muted, #888)', textDecoration: 'underline' }}
+        >
+          {t('auth.adminLogin')}
+        </Link>
+      )}
     </div>
   );
 };

--- a/frontend/src/types/dailyRecord.ts
+++ b/frontend/src/types/dailyRecord.ts
@@ -26,6 +26,12 @@ export interface BlockerType {
   is_active: boolean;
 }
 
+export interface AbsenceType {
+  id: string;
+  name: string;
+  is_active: boolean;
+}
+
 export interface Project {
   id: string;
   name: string;
@@ -103,7 +109,7 @@ export interface Absence {
   id: string;
   user_id: string;
   record_date: string;
-  absence_type: 'holiday' | 'exchanged_holiday' | 'illness' | 'other';
+  absence_type: AbsenceType;
   note: string | null;
   created_at: string;
 }


### PR DESCRIPTION
## What changed and why

Implements absence types as a FK-backed controlled list (replacing the previous enum), adds full CRUD management in the Admin Lists page, and introduces a local login option for development environments.

Closes #17

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [ ] CI/CD / infra
- [ ] Dependency upgrade

## Component(s) affected

- [x] backend
- [x] frontend
- [x] database schema / migration
- [x] auth
- [ ] notifications / email
- [ ] LLM integration

## Testing done

- [x] Existing tests pass (`uv run pytest` / `yarn lint && tsc --noEmit`)
- [x] New tests added (if applicable)
- [x] Manually tested locally

New test files: `test_controlled_lists.py`, `test_auth.py` (local login coverage).

## Invariants checklist

- [ ] Edit window lock logic untouched or correctly updated
- [ ] Private fields (`day_load`, `blocker_text`) stripped for non-owners/non-leaders
- [ ] WebSocket visibility uses the same filter as REST
- [x] `carried_from_id` is immutable after creation (not set or mutated here)
- [x] Exactly one `is_primary=true` tag per TaskEntry enforced (if task entry code touched)
- [x] DailyRecord ↔ Absence mutual exclusion checked (if record creation/update touched)
- [x] Soft-delete pattern used (no hard-delete on controlled lists) — absence_types uses `is_active` flag
- [ ] LLM user content injected in `<user_data>` delimiters (if LLM code touched)
- [ ] N/A — none of the above apply to this change

## Screenshots (UI changes only)

<!-- Admin Lists page now includes an Absence Types section. LocalLoginPage added for dev use. -->
