### PR TITLE
Add GitHub Projects integration to Project model

### DIFF
--- a/.github/ISSUE_TEMPLATE/refactor.yml
+++ b/.github/ISSUE_TEMPLATE/refactor.yml
@@ -1,43 +1,36 @@
-name: Chore
-description: Maintenance work — tech debt, docs update, dependency upgrade, test coverage, CI/CD, or other non-feature non-refactor tasks
-labels: ["chore"]
+name: Refactor
+description: Code restructuring that improves design, readability, or performance without changing external behavior
+labels: ["refactor"]
 body:
   - type: markdown
     attributes:
       value: |
-        Use this template for maintenance tasks that don't add user-visible features and don't restructure existing code. For code restructuring, use the **Refactor** template instead.
-
-  - type: dropdown
-    id: task-type
-    attributes:
-      label: Task Type
-      options:
-        - tech-debt
-        - docs
-        - dependency-upgrade
-        - test
-        - ci-cd
-        - infra
-        - other
-    validations:
-      required: true
+        Use this template for internal code changes that do not alter observable behavior — renaming, extracting modules, simplifying logic, improving type safety, etc.
 
   - type: textarea
     id: description
     attributes:
       label: Description
-      description: What needs to be done and why.
+      description: What is being refactored and why. Include the current pain point.
     validations:
       required: true
+
+  - type: textarea
+    id: approach
+    attributes:
+      label: Proposed Approach
+      description: How will you restructure it? Mention any patterns, abstractions, or conventions you plan to follow.
+    validations:
+      required: false
 
   - type: textarea
     id: definition-of-done
     attributes:
       label: Definition of Done
       placeholder: |
-        - [ ] ...
-        - [ ] Tests pass
+        - [ ] No behavior change (existing tests still pass)
         - [ ] No ruff / mypy / tsc errors
+        - [ ] Code reviewed
     validations:
       required: true
 
@@ -71,3 +64,4 @@ body:
     id: context
     attributes:
       label: Additional Context
+      description: Related issues, prior art, or references.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Rules that MUST be followed in every coding task. Violating any of these is a bu
 - Self-assessment tags are many-to-many via `DailyWorkLogSelfAssessmentTag` junction table with `is_primary` boolean. Exactly one tag per `DailyWorkLog` must have `is_primary=true`. Enforced at DB level via a partial unique index on `(daily_work_log_id) WHERE is_primary = TRUE`; also validate at app level.
 - Controlled lists (categories, blocker types, work types) use soft-delete (`is_active` flag, default `true`). Never hard-delete. Historical records keep FK references; deactivated items hidden from new-entry forms only.
 - `Task.work_type_id` is a nullable FK into the `work_types` controlled-list table (not an enum).
-- Project table: single table with `scope ENUM(personal, team, cross_team)`. `team_id` is NULL for cross_team projects.
+- Project table: single table linked to a GitHub Project. Columns: `github_project_node_id` (String, unique, not null), `github_project_number` (Integer, nullable), `github_project_owner` (String, nullable). No `scope`, `team_id`, or `github_repo` columns. Visibility is creator-only (`created_by` FK to `users`); admins see all.
 - All dates stored as `DATE` (not TIMESTAMP). Single system timezone: **JST (Asia/Tokyo)**. No per-user timezone offset.
 - No `locked` boolean column on DailyRecord. Lock status is always computed from dates (see Edit Window).
 
@@ -44,7 +44,6 @@ Rules that MUST be followed in every coding task. Violating any of these is a bu
 - Quarterly report drafts are private to the member. Leader sees only finalized reports.
 - Missing day reminder fires only on working days (exclude weekends + holidays from the holiday calendar).
 - Team membership tracks `(user_id, team_id, joined_at, left_at)`. Old leader sees records up to `left_at`; new leader from `joined_at` onward.
-- When leader promotes team → cross-team project, original creator gets an in-app notification. No veto.
 
 ## Output Language
 

--- a/backend/alembic/versions/b3d1e2f4a896_github_linked_project_schema.py
+++ b/backend/alembic/versions/b3d1e2f4a896_github_linked_project_schema.py
@@ -1,0 +1,61 @@
+"""github_linked_project_schema
+
+Revision ID: b3d1e2f4a896
+Revises: fcdd7f228503
+Create Date: 2026-04-23 00:00:00.000000
+
+Drops scope/team_id/github_repo from projects and replaces them with
+GitHub Project identity columns (github_project_node_id, github_project_number,
+github_project_owner).  The projects table (and its FK-dependent tasks rows)
+are wiped first — wipe strategy agreed in issue #75.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3d1e2f4a896"
+down_revision: str | Sequence[str] | None = "fcdd7f228503"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    # Wipe dependent rows first so FK constraints don't block column drops.
+    op.execute("TRUNCATE TABLE tasks RESTART IDENTITY CASCADE")
+    op.execute("TRUNCATE TABLE projects RESTART IDENTITY CASCADE")
+
+    # Drop old columns (drop FK constraint on team_id explicitly first).
+    op.drop_constraint("projects_team_id_fkey", "projects", type_="foreignkey")
+    op.drop_column("projects", "scope")
+    op.drop_column("projects", "team_id")
+    op.drop_column("projects", "github_repo")
+
+    # Add new GitHub-identity columns.
+    op.add_column(
+        "projects",
+        sa.Column("github_project_node_id", sa.String(), nullable=False),
+    )
+    op.create_unique_constraint(
+        "uq_projects_github_project_node_id",
+        "projects",
+        ["github_project_node_id"],
+    )
+    op.add_column(
+        "projects",
+        sa.Column("github_project_number", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "projects",
+        sa.Column("github_project_owner", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    # The wipe strategy makes a true downgrade impossible.
+    raise NotImplementedError(
+        "Downgrade not supported: data was wiped during upgrade (issue #75)."
+    )

--- a/backend/alembic/versions/d0b797503987_merge_github_project_and_oauth_heads.py
+++ b/backend/alembic/versions/d0b797503987_merge_github_project_and_oauth_heads.py
@@ -1,0 +1,28 @@
+"""merge_github_project_and_oauth_heads
+
+Revision ID: d0b797503987
+Revises: b3d1e2f4a896, e1f2a3b4c5d6
+Create Date: 2026-04-23 19:24:19.919120
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'd0b797503987'
+down_revision: Union[str, Sequence[str], None] = ('b3d1e2f4a896', 'e1f2a3b4c5d6')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    pass
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    pass

--- a/backend/alembic/versions/g1h2i3j4k5l6_add_github_status_to_tasks.py
+++ b/backend/alembic/versions/g1h2i3j4k5l6_add_github_status_to_tasks.py
@@ -1,0 +1,27 @@
+"""add_github_status_to_tasks
+
+Revision ID: g1h2i3j4k5l6
+Revises: fcdd7f228503
+Create Date: 2026-04-23 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "g1h2i3j4k5l6"
+down_revision: Union[str, None] = "d0b797503987"
+branch_labels: Union[Sequence[str], None] = None
+depends_on: Union[Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("tasks", sa.Column("github_status", sa.String(100), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("tasks", "github_status")

--- a/backend/app/api/v1/auth.py
+++ b/backend/app/api/v1/auth.py
@@ -315,7 +315,7 @@ async def github_authorize(
     params = {
         "client_id": settings.GITHUB_CLIENT_ID,
         "redirect_uri": settings.GITHUB_REDIRECT_URI,
-        "scope": "repo read:user",
+        "scope": "repo read:user read:project",
         "state": state,
     }
     return {"url": f"{_GITHUB_AUTHORIZE_URL}?{urlencode(params)}"}

--- a/backend/app/api/v1/export.py
+++ b/backend/app/api/v1/export.py
@@ -491,13 +491,13 @@ async def export_bulk(
     )
     _sheet(
         "Projects",
-        ["id", "name", "scope", "team_id", "is_active", "created_at"],
+        ["id", "name", "github_project_node_id", "github_project_owner", "is_active", "created_at"],
         [
             [
                 str(p.id),
                 p.name,
-                p.scope,
-                str(p.team_id) if p.team_id else "",
+                p.github_project_node_id,
+                p.github_project_owner or "",
                 p.is_active,
                 str(p.created_at),
             ]

--- a/backend/app/api/v1/export.py
+++ b/backend/app/api/v1/export.py
@@ -491,7 +491,14 @@ async def export_bulk(
     )
     _sheet(
         "Projects",
-        ["id", "name", "github_project_node_id", "github_project_owner", "is_active", "created_at"],
+        [
+            "id",
+            "name",
+            "github_project_node_id",
+            "github_project_owner",
+            "is_active",
+            "created_at",
+        ],
         [
             [
                 str(p.id),

--- a/backend/app/api/v1/projects.py
+++ b/backend/app/api/v1/projects.py
@@ -8,7 +8,14 @@ from app.core.deps import require_active_user
 from app.db.engine import get_db
 from app.db.models.project import Project
 from app.db.models.user import User
-from app.db.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
+from app.db.schemas.project import (
+    GitHubAvailableProjectItem,
+    ProjectCreate,
+    ProjectResponse,
+    ProjectUpdate,
+)
+from app.services.github_autofill import resolve_github_token
+from app.services.github_projects import fetch_available_github_projects
 
 router = APIRouter()
 
@@ -121,3 +128,25 @@ async def update_project(
     await db.commit()
     await db.refresh(project)
     return ProjectResponse.model_validate(project)
+
+
+@router.get(
+    "/projects/github/available", response_model=list[GitHubAvailableProjectItem]
+)
+async def list_available_github_projects(
+    current_user: User = Depends(require_active_user),
+) -> list[GitHubAvailableProjectItem]:
+    """Return all GitHub Projects V2 accessible to the authenticated user.
+
+    Requires the user to have a linked GitHub OAuth token.
+    """
+    if not current_user.github_access_token_enc:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="No GitHub account linked. Please connect your GitHub account first.",
+        )
+
+    github_token = await resolve_github_token(current_user)
+    assert github_token is not None
+
+    return await fetch_available_github_projects(github_token)

--- a/backend/app/api/v1/projects.py
+++ b/backend/app/api/v1/projects.py
@@ -6,24 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.deps import require_active_user
 from app.db.engine import get_db
-from app.db.models.notification import Notification
-from app.db.models.project import Project, ProjectScope
-from app.db.models.team import TeamMembership
+from app.db.models.project import Project
 from app.db.models.user import User
 from app.db.schemas.project import ProjectCreate, ProjectResponse, ProjectUpdate
 
 router = APIRouter()
-
-
-async def _get_user_team(user: User, db: AsyncSession) -> uuid.UUID | None:
-    result = await db.execute(
-        select(TeamMembership).where(
-            TeamMembership.user_id == user.id,
-            TeamMembership.left_at.is_(None),
-        )
-    )
-    m = result.scalar_one_or_none()
-    return m.team_id if m else None
 
 
 @router.post(
@@ -34,21 +21,23 @@ async def create_project(
     db: AsyncSession = Depends(get_db),
     current_user: User = Depends(require_active_user),
 ):
-    if body.scope == "cross_team":
-        if not (current_user.is_leader or current_user.is_admin):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail="Leader or admin required for cross-team projects",
-            )
-        team_id = None
-    else:
-        team_id = await _get_user_team(current_user, db)
+    existing = await db.execute(
+        select(Project).where(
+            Project.github_project_node_id == body.github_project_node_id
+        )
+    )
+    if existing.scalar_one_or_none() is not None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="A project with this GitHub Project node ID already exists",
+        )
 
     project = Project(
         id=uuid.uuid4(),
         name=body.name,
-        scope=ProjectScope(body.scope),
-        team_id=team_id,
+        github_project_node_id=body.github_project_node_id,
+        github_project_number=body.github_project_number,
+        github_project_owner=body.github_project_owner,
         created_by=current_user.id,
         is_active=True,
     )
@@ -69,21 +58,9 @@ async def list_projects(
             status_code=status.HTTP_403_FORBIDDEN, detail="Admin access required"
         )
 
-    user_team_id = await _get_user_team(current_user, db)
-
-    from sqlalchemy import or_
-
-    conditions = or_(
-        # Own personal projects
-        (Project.scope == ProjectScope.personal)
-        & (Project.created_by == current_user.id),
-        # Own team projects
-        (Project.scope == ProjectScope.team) & (Project.team_id == user_team_id),
-        # All cross-team projects
-        Project.scope == ProjectScope.cross_team,
-    )
-
-    q = select(Project).where(conditions)
+    q = select(Project)
+    if not current_user.is_admin:
+        q = q.where(Project.created_by == current_user.id)
     if not include_inactive:
         q = q.where(Project.is_active.is_(True))
 
@@ -104,19 +81,10 @@ async def get_project(
             status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
         )
 
-    user_team_id = await _get_user_team(current_user, db)
-
-    if project.scope == ProjectScope.personal:
-        if project.created_by != current_user.id and not current_user.is_admin:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
-    elif project.scope == ProjectScope.team:
-        if not current_user.is_admin and project.team_id != user_team_id:
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
-            )
-    # cross_team: any authenticated user may read
+    if project.created_by != current_user.id and not current_user.is_admin:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Access denied"
+        )
 
     return ProjectResponse.model_validate(project)
 
@@ -145,61 +113,10 @@ async def update_project(
         project.name = body.name
     if body.is_active is not None:
         project.is_active = body.is_active
-
-    await db.commit()
-    await db.refresh(project)
-    return ProjectResponse.model_validate(project)
-
-
-@router.post("/projects/{project_id}/promote", response_model=ProjectResponse)
-async def promote_project(
-    project_id: uuid.UUID,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(require_active_user),
-):
-    result = await db.execute(select(Project).where(Project.id == project_id))
-    project = result.scalar_one_or_none()
-    if project is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND, detail="Project not found"
-        )
-
-    if project.scope != ProjectScope.team:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Only team-scoped projects can be promoted",
-        )
-
-    # Must be admin OR (leader AND member of the project's team)
-    is_authorized = current_user.is_admin
-    if not is_authorized and current_user.is_leader:
-        membership_result = await db.execute(
-            select(TeamMembership).where(
-                TeamMembership.user_id == current_user.id,
-                TeamMembership.team_id == project.team_id,
-                TeamMembership.left_at.is_(None),
-            )
-        )
-        if membership_result.scalar_one_or_none() is not None:
-            is_authorized = True
-
-    if not is_authorized:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Only the project's team leader or admin can promote",
-        )
-
-    project.scope = ProjectScope.cross_team
-    project.team_id = None
-
-    notification = Notification(
-        id=uuid.uuid4(),
-        user_id=project.created_by,
-        trigger_type="project_promoted",
-        title="Your project was promoted to cross-team",
-        data={"project_id": str(project_id)},
-    )
-    db.add(notification)
+    if body.github_project_number is not None:
+        project.github_project_number = body.github_project_number
+    if body.github_project_owner is not None:
+        project.github_project_owner = body.github_project_owner
 
     await db.commit()
     await db.refresh(project)

--- a/backend/app/api/v1/tasks.py
+++ b/backend/app/api/v1/tasks.py
@@ -92,6 +92,7 @@ async def create_task(
         due_date=body.due_date,
         blocker_type_id=body.blocker_type_id,
         github_issue_url=body.github_issue_url,
+        github_status=body.github_status,
         insight=body.insight,
         closed_at=closed_at,
     )
@@ -207,6 +208,8 @@ async def update_task(
         task.is_active = body.is_active
     if body.insight is not None:
         task.insight = body.insight
+    if body.github_status is not None:
+        task.github_status = body.github_status
 
     if body.status is not None:
         new_status = TaskStatus(body.status)

--- a/backend/app/db/models/project.py
+++ b/backend/app/db/models/project.py
@@ -1,18 +1,10 @@
-import enum
 import uuid
 from datetime import datetime
 
-from sqlalchemy import Boolean, DateTime, ForeignKey, String, Uuid, func
-from sqlalchemy import Enum as SAEnum
+from sqlalchemy import Boolean, DateTime, ForeignKey, Integer, String, Uuid, func
 from sqlalchemy.orm import Mapped, mapped_column
 
 from . import Base
-
-
-class ProjectScope(enum.StrEnum):
-    personal = "personal"
-    team = "team"
-    cross_team = "cross_team"
 
 
 class Project(Base):
@@ -21,12 +13,11 @@ class Project(Base):
         Uuid(as_uuid=True), primary_key=True, default=uuid.uuid4
     )
     name: Mapped[str] = mapped_column(String, nullable=False)
-    scope: Mapped[ProjectScope] = mapped_column(
-        SAEnum(ProjectScope, name="project_scope", native_enum=False), nullable=False
+    github_project_node_id: Mapped[str] = mapped_column(
+        String, unique=True, nullable=False
     )
-    team_id: Mapped[uuid.UUID | None] = mapped_column(
-        Uuid(as_uuid=True), ForeignKey("teams.id"), nullable=True
-    )
+    github_project_number: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    github_project_owner: Mapped[str | None] = mapped_column(String, nullable=True)
     created_by: Mapped[uuid.UUID] = mapped_column(
         Uuid(as_uuid=True), ForeignKey("users.id"), nullable=False
     )
@@ -34,4 +25,3 @@ class Project(Base):
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False
     )
-    github_repo: Mapped[str | None] = mapped_column(String, nullable=True)

--- a/backend/app/db/models/task.py
+++ b/backend/app/db/models/task.py
@@ -89,6 +89,7 @@ class Task(Base):
         Uuid(as_uuid=True), ForeignKey("blocker_types.id"), nullable=True
     )
     github_issue_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    github_status: Mapped[str | None] = mapped_column(String(100), nullable=True)
     insight: Mapped[str | None] = mapped_column(String(500), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), server_default=func.now(), nullable=False

--- a/backend/app/db/schemas/project.py
+++ b/backend/app/db/schemas/project.py
@@ -31,3 +31,11 @@ class ProjectResponse(BaseModel):
     created_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class GitHubAvailableProjectItem(BaseModel):
+    node_id: str
+    number: int
+    title: str
+    owner_login: str
+    url: str

--- a/backend/app/db/schemas/project.py
+++ b/backend/app/db/schemas/project.py
@@ -2,32 +2,32 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Literal
 
 from pydantic import BaseModel
 
 
 class ProjectCreate(BaseModel):
     name: str
-    scope: Literal["personal", "team", "cross_team"]
-    team_id: uuid.UUID | None = None
-    github_repo: str | None = None
+    github_project_node_id: str
+    github_project_number: int | None = None
+    github_project_owner: str | None = None
 
 
 class ProjectUpdate(BaseModel):
     name: str | None = None
     is_active: bool | None = None
-    github_repo: str | None = None
+    github_project_number: int | None = None
+    github_project_owner: str | None = None
 
 
 class ProjectResponse(BaseModel):
     id: uuid.UUID
     name: str
-    scope: str
-    team_id: uuid.UUID | None
+    github_project_node_id: str
+    github_project_number: int | None
+    github_project_owner: str | None
     created_by: uuid.UUID
     is_active: bool
     created_at: datetime
-    github_repo: str | None
 
     model_config = {"from_attributes": True}

--- a/backend/app/db/schemas/task.py
+++ b/backend/app/db/schemas/task.py
@@ -92,6 +92,7 @@ class TaskCreate(BaseModel):
     due_date: date | None = None
     blocker_type_id: uuid.UUID | None = None
     github_issue_url: str | None = None
+    github_status: str | None = None
     insight: str | None = None
 
     @field_validator("estimated_effort")
@@ -121,6 +122,7 @@ class TaskUpdate(BaseModel):
     due_date: date | None = None
     blocker_type_id: uuid.UUID | None = None
     github_issue_url: str | None = None
+    github_status: str | None = None
     is_active: bool | None = None
     insight: str | None = None
 
@@ -153,6 +155,7 @@ class TaskResponse(BaseModel):
     due_date: date | None
     blocker_type_id: uuid.UUID | None
     github_issue_url: str | None
+    github_status: str | None
     insight: str | None
     created_by: uuid.UUID
     created_at: datetime
@@ -175,3 +178,7 @@ class TaskAutoFillResponse(BaseModel):
     work_type_id: uuid.UUID | None = None
     estimated_effort: int | None = None
     insight: str | None = None
+    # github_status is the raw GitHub Project board column (e.g. "In Progress").
+    # status is the derived teamtakt internal value mapped from github_status.
+    github_status: str | None = None
+    status: Literal["todo", "running", "done", "blocked"] = "todo"

--- a/backend/app/db/schemas/task.py
+++ b/backend/app/db/schemas/task.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, field_validator
 
-from app.db.models.task import EnergyType, TaskPriority
+from app.db.models.task import EnergyType, TaskPriority, TaskStatus
 
 _FIBONACCI = frozenset({1, 2, 3, 5, 8})
 
@@ -181,4 +181,4 @@ class TaskAutoFillResponse(BaseModel):
     # github_status is the raw GitHub Project board column (e.g. "In Progress").
     # status is the derived teamtakt internal value mapped from github_status.
     github_status: str | None = None
-    status: Literal["todo", "running", "done", "blocked"] = "todo"
+    status: TaskStatus = TaskStatus.todo

--- a/backend/app/services/github_autofill.py
+++ b/backend/app/services/github_autofill.py
@@ -9,6 +9,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.config import settings
 from app.core.token_encryption import decrypt_token
 from app.db.models.category import Category
+from app.db.models.task import TaskStatus
 from app.db.models.user import User
 from app.db.schemas.task import TaskAutoFillResponse
 
@@ -20,21 +21,23 @@ _GITHUB_API_BASE = "https://api.github.com"
 # GitHub Project board status → teamtakt internal status
 # Mapping is case-insensitive; unknown values fall back to "todo".
 # ---------------------------------------------------------------------------
-_GITHUB_STATUS_TO_TASK_STATUS: dict[str, str] = {
-    "backlog": "todo",
-    "sprint backlog": "todo",
-    "in progress": "running",
-    "in review": "running",
-    "done": "done",
+_GITHUB_STATUS_TO_TASK_STATUS: dict[str, TaskStatus] = {
+    "backlog": TaskStatus.todo,
+    "sprint backlog": TaskStatus.todo,
+    "in progress": TaskStatus.running,
+    "in review": TaskStatus.running,
+    "done": TaskStatus.done,
 }
 
 
-def map_github_status_to_task_status(github_status: str) -> str:
+def map_github_status_to_task_status(github_status: str) -> TaskStatus:
     """Map a GitHub Project board column name to a teamtakt TaskStatus value.
 
     Unknown/unrecognised column names default to ``"todo"``.
     """
-    return _GITHUB_STATUS_TO_TASK_STATUS.get(github_status.strip().lower(), "todo")
+    return _GITHUB_STATUS_TO_TASK_STATUS.get(
+        github_status.strip().lower(), TaskStatus.todo
+    )
 
 
 class GitHubTokenRevokedError(Exception):
@@ -155,7 +158,9 @@ async def map_to_task_fields(
         if isinstance(raw, str) and raw:
             github_status = raw
     derived_status = (
-        map_github_status_to_task_status(github_status) if github_status else "todo"
+        map_github_status_to_task_status(github_status)
+        if github_status
+        else TaskStatus.todo
     )
 
     return TaskAutoFillResponse(

--- a/backend/app/services/github_autofill.py
+++ b/backend/app/services/github_autofill.py
@@ -16,6 +16,26 @@ _GITHUB_ISSUE_RE = re.compile(r"^https://github\.com/([^/]+)/([^/]+)/issues/(\d+
 # GitHub API base URL is hardcoded — never derived from user input (OWASP A10)
 _GITHUB_API_BASE = "https://api.github.com"
 
+# ---------------------------------------------------------------------------
+# GitHub Project board status → teamtakt internal status
+# Mapping is case-insensitive; unknown values fall back to "todo".
+# ---------------------------------------------------------------------------
+_GITHUB_STATUS_TO_TASK_STATUS: dict[str, str] = {
+    "backlog": "todo",
+    "sprint backlog": "todo",
+    "in progress": "running",
+    "in review": "running",
+    "done": "done",
+}
+
+
+def map_github_status_to_task_status(github_status: str) -> str:
+    """Map a GitHub Project board column name to a teamtakt TaskStatus value.
+
+    Unknown/unrecognised column names default to ``"todo"``.
+    """
+    return _GITHUB_STATUS_TO_TASK_STATUS.get(github_status.strip().lower(), "todo")
+
 
 class GitHubTokenRevokedError(Exception):
     """Raised when the stored GitHub token is invalid or revoked (HTTP 401)."""
@@ -127,9 +147,22 @@ async def map_to_task_fields(
         if isinstance(raw, str) and raw:
             insight = raw[:500]
 
+    # Resolve github_status and derive teamtakt status
+    github_status: str | None = None
+    if github_field_map and "Status" in github_field_map:
+        field_key = github_field_map["Status"]
+        raw = issue.get(field_key)
+        if isinstance(raw, str) and raw:
+            github_status = raw
+    derived_status = (
+        map_github_status_to_task_status(github_status) if github_status else "todo"
+    )
+
     return TaskAutoFillResponse(
         title=title,
         description=description,
         category_id=category_id,
         insight=insight,
+        github_status=github_status,
+        status=derived_status,
     )

--- a/backend/app/services/github_projects.py
+++ b/backend/app/services/github_projects.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import logging
+
 import httpx
 from fastapi import HTTPException, status
 
 from app.db.schemas.project import GitHubAvailableProjectItem
+
+logger = logging.getLogger(__name__)
 
 # GitHub GraphQL endpoint — hardcoded, never derived from user input (OWASP A10)
 _GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
@@ -75,11 +79,17 @@ async def fetch_available_github_projects(
             )
 
             if response.status_code == 401:
+                logger.warning("GitHub token rejected (401): %s", response.text[:500])
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
                     detail="GitHub token is invalid or revoked. Please re-link your GitHub account.",
                 )
             if response.status_code != 200:
+                logger.error(
+                    "GitHub API returned status %d: %s",
+                    response.status_code,
+                    response.text[:500],
+                )
                 raise HTTPException(
                     status_code=status.HTTP_502_BAD_GATEWAY,
                     detail=f"GitHub API returned unexpected status {response.status_code}",
@@ -87,19 +97,29 @@ async def fetch_available_github_projects(
 
             data = response.json()
 
+            # GitHub GraphQL returns partial errors alongside data (e.g. org
+            # access restrictions).  Log them as warnings but only raise if
+            # there is no usable data at all.
             if "errors" in data:
                 error_msg = "; ".join(
                     e.get("message", "unknown") for e in data["errors"]
                 )
-                raise HTTPException(
-                    status_code=status.HTTP_502_BAD_GATEWAY,
-                    detail=f"GitHub GraphQL error: {error_msg}",
+                if not data.get("data"):
+                    logger.error("GitHub GraphQL fatal error: %s", error_msg)
+                    raise HTTPException(
+                        status_code=status.HTTP_502_BAD_GATEWAY,
+                        detail=f"GitHub GraphQL error: {error_msg}",
+                    )
+                logger.warning(
+                    "GitHub GraphQL partial error (data still returned): %s", error_msg
                 )
 
             viewer = data["data"]["viewer"]
 
             # Collect personal projects from this page
             for node in viewer["projectsV2"]["nodes"]:
+                if node is None:
+                    continue
                 node_id: str = node["id"]
                 if node_id not in seen:
                     seen.add(node_id)
@@ -114,9 +134,14 @@ async def fetch_available_github_projects(
                     )
 
             # Collect org projects (first page only — no further pagination)
+            # Orgs with OAuth App access restrictions return null nodes; skip them.
             if cursor is None:
                 for org in viewer["organizations"]["nodes"]:
+                    if org is None:
+                        continue
                     for node in org["projectsV2"]["nodes"]:
+                        if node is None:
+                            continue
                         node_id = node["id"]
                         if node_id not in seen:
                             seen.add(node_id)

--- a/backend/app/services/github_projects.py
+++ b/backend/app/services/github_projects.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import httpx
+from fastapi import HTTPException, status
+
+from app.db.schemas.project import GitHubAvailableProjectItem
+
+# GitHub GraphQL endpoint — hardcoded, never derived from user input (OWASP A10)
+_GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+
+# Viewer personal projects + first page of org projects in one query.
+# NOTE: Org project pagination (>100 projects per org) is not implemented;
+# this returns only the first 100 projects per org (known limitation).
+_PROJECTS_QUERY = """
+query($cursor: String) {
+  viewer {
+    projectsV2(first: 100, after: $cursor) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        id
+        number
+        title
+        url
+        owner {
+          ... on User { login }
+          ... on Organization { login }
+        }
+      }
+    }
+    organizations(first: 100) {
+      nodes {
+        projectsV2(first: 100) {
+          nodes {
+            id
+            number
+            title
+            url
+            owner {
+              ... on Organization { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+async def fetch_available_github_projects(
+    github_token: str,
+) -> list[GitHubAvailableProjectItem]:
+    """Return all GitHub Projects V2 accessible to the user identified by *github_token*.
+
+    Paginates through the viewer's personal projects. Org projects are fetched
+    for the first page only (first 100 per org).
+
+    Raises ``HTTPException(403)`` if the token is invalid or revoked.
+    Raises ``HTTPException(502)`` if GitHub returns unexpected GraphQL errors.
+    """
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Content-Type": "application/json",
+    }
+
+    seen: set[str] = set()
+    results: list[GitHubAvailableProjectItem] = []
+    cursor: str | None = None
+
+    async with httpx.AsyncClient(timeout=15.0) as client:
+        while True:
+            payload: dict = {"query": _PROJECTS_QUERY, "variables": {"cursor": cursor}}
+            response = await client.post(
+                _GITHUB_GRAPHQL_URL, json=payload, headers=headers
+            )
+
+            if response.status_code == 401:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="GitHub token is invalid or revoked. Please re-link your GitHub account.",
+                )
+            if response.status_code != 200:
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"GitHub API returned unexpected status {response.status_code}",
+                )
+
+            data = response.json()
+
+            if "errors" in data:
+                error_msg = "; ".join(
+                    e.get("message", "unknown") for e in data["errors"]
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_502_BAD_GATEWAY,
+                    detail=f"GitHub GraphQL error: {error_msg}",
+                )
+
+            viewer = data["data"]["viewer"]
+
+            # Collect personal projects from this page
+            for node in viewer["projectsV2"]["nodes"]:
+                node_id: str = node["id"]
+                if node_id not in seen:
+                    seen.add(node_id)
+                    results.append(
+                        GitHubAvailableProjectItem(
+                            node_id=node_id,
+                            number=node["number"],
+                            title=node["title"],
+                            owner_login=node["owner"]["login"],
+                            url=node["url"],
+                        )
+                    )
+
+            # Collect org projects (first page only — no further pagination)
+            if cursor is None:
+                for org in viewer["organizations"]["nodes"]:
+                    for node in org["projectsV2"]["nodes"]:
+                        node_id = node["id"]
+                        if node_id not in seen:
+                            seen.add(node_id)
+                            results.append(
+                                GitHubAvailableProjectItem(
+                                    node_id=node_id,
+                                    number=node["number"],
+                                    title=node["title"],
+                                    owner_login=node["owner"]["login"],
+                                    url=node["url"],
+                                )
+                            )
+
+            page_info = viewer["projectsV2"]["pageInfo"]
+            if not page_info["hasNextPage"]:
+                break
+            cursor = page_info["endCursor"]
+
+    return results

--- a/backend/app/tests/test_export_sharing.py
+++ b/backend/app/tests/test_export_sharing.py
@@ -5,7 +5,7 @@ from datetime import UTC, datetime
 from app.core.security import create_access_token
 from app.db.models.category import Category
 from app.db.models.daily_record import DailyRecord
-from app.db.models.project import Project, ProjectScope
+from app.db.models.project import Project
 from app.db.models.task import DailyWorkLog, Task, TaskStatus
 from app.db.models.team import Team, TeamMembership, TeamSettings
 from app.db.models.user import User
@@ -61,9 +61,13 @@ async def make_category(db, name="TestCat"):
 
 
 async def make_project(
-    db, name, created_by, *, scope=ProjectScope.personal, team_id=None
+    db, name, created_by
 ):
-    p = Project(name=name, scope=scope, created_by=created_by, team_id=team_id)
+    p = Project(
+        name=name,
+        github_project_node_id=f"PVT_{name}",
+        created_by=created_by,
+    )
     db.add(p)
     await db.commit()
     await db.refresh(p)
@@ -166,9 +170,7 @@ async def test_leader_export_team_csv(client, db_session):
     await make_membership(db_session, leader.id, team.id)
     await make_membership(db_session, member.id, team.id)
     cat = await make_category(db_session, "exp03_Cat")
-    proj = await make_project(
-        db_session, "exp03_Proj", member.id, scope=ProjectScope.team, team_id=team.id
-    )
+    proj = await make_project(db_session, "exp03_Proj", member.id)
     dr = await make_daily_record(db_session, member.id, "2025-01-08")
     await make_work_log(db_session, dr.id, cat.id, proj.id, member.id)
 

--- a/backend/app/tests/test_export_sharing.py
+++ b/backend/app/tests/test_export_sharing.py
@@ -60,9 +60,7 @@ async def make_category(db, name="TestCat"):
     return cat
 
 
-async def make_project(
-    db, name, created_by
-):
+async def make_project(db, name, created_by):
     p = Project(
         name=name,
         github_project_node_id=f"PVT_{name}",

--- a/backend/app/tests/test_projects.py
+++ b/backend/app/tests/test_projects.py
@@ -2,6 +2,7 @@
 
 import uuid
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
 
 from app.core.security import create_access_token
 from app.db.models.team import Team, TeamMembership, TeamSettings
@@ -281,3 +282,88 @@ async def test_non_owner_cannot_update_project(client, db_session):
         headers=auth(other_tok),
     )
     assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 11. GET /projects/github/available — success (mocked GitHub GraphQL)
+# ---------------------------------------------------------------------------
+
+
+async def test_list_available_github_projects_success(client, db_session):
+    user, tok = await make_active_user(db_session, "p11_user@t.com")
+
+    # Store a plaintext token (no github_token_iv) to use the dev/local fallback path
+    user.github_access_token_enc = "fake_github_token"
+    await db_session.commit()
+
+    mock_items = [
+        {
+            "node_id": "PVT_mock1",
+            "number": 10,
+            "title": "Mock Project",
+            "owner_login": "mock-org",
+            "url": "https://github.com/orgs/mock-org/projects/10",
+        }
+    ]
+
+    with patch(
+        "app.api.v1.projects.fetch_available_github_projects",
+        new=AsyncMock(return_value=mock_items),
+    ):
+        resp = await client.get("/api/v1/projects/github/available", headers=auth(tok))
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data) == 1
+    assert data[0]["node_id"] == "PVT_mock1"
+    assert data[0]["title"] == "Mock Project"
+
+
+# ---------------------------------------------------------------------------
+# 12. GET /projects/github/available — 403 when no GitHub token linked
+# ---------------------------------------------------------------------------
+
+
+async def test_list_available_github_projects_no_token(client, db_session):
+    user, tok = await make_active_user(db_session, "p12_user@t.com")
+    # user.github_access_token_enc is None by default
+
+    resp = await client.get("/api/v1/projects/github/available", headers=auth(tok))
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 13. POST /projects — old `scope` field silently ignored → 201, scope absent
+# ---------------------------------------------------------------------------
+
+
+async def test_create_project_scope_field_ignored(client, db_session):
+    user, tok = await make_active_user(db_session, "p13_user@t.com")
+
+    resp = await client.post(
+        "/api/v1/projects",
+        json={
+            "name": "p13_Project",
+            "github_project_node_id": "p13_NODE",
+            "scope": "team",  # legacy field — no longer in schema
+        },
+        headers=auth(tok),
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert "scope" not in data
+
+
+# ---------------------------------------------------------------------------
+# 14. POST /projects/{id}/promote — endpoint removed → 404
+# ---------------------------------------------------------------------------
+
+
+async def test_promote_endpoint_removed(client, db_session):
+    user, tok = await make_active_user(db_session, "p14_user@t.com")
+
+    resp = await client.post(
+        f"/api/v1/projects/{uuid.uuid4()}/promote",
+        headers=auth(tok),
+    )
+    assert resp.status_code == 404

--- a/backend/app/tests/test_projects.py
+++ b/backend/app/tests/test_projects.py
@@ -1,11 +1,9 @@
-"""Tests for project endpoints (p05)."""
+"""Tests for project endpoints (post-#77 GitHub-linked schema)."""
 
+import uuid
 from datetime import UTC, datetime
 
-from sqlalchemy import select
-
 from app.core.security import create_access_token
-from app.db.models.notification import Notification
 from app.db.models.team import Team, TeamMembership, TeamSettings
 from app.db.models.user import User
 
@@ -14,17 +12,25 @@ from app.db.models.user import User
 # ---------------------------------------------------------------------------
 
 
-async def make_user(db, email, *, is_leader=False, is_admin=False):
+async def make_user(db, email, *, is_admin=False):
     user = User(
         email=email,
         display_name=email.split("@")[0],
-        is_leader=is_leader,
         is_admin=is_admin,
     )
     db.add(user)
     await db.commit()
     await db.refresh(user)
     return user, create_access_token({"sub": str(user.id)})
+
+
+async def make_active_user(db, email, *, is_admin=False):
+    """Create a user and assign them to a unique team (active, non-lobby state)."""
+    user, tok = await make_user(db, email, is_admin=is_admin)
+    if not is_admin:
+        team = await make_team(db, f"team_for_{email}")
+        await make_membership(db, user.id, team.id)
+    return user, tok
 
 
 async def make_team(db, name):
@@ -48,150 +54,118 @@ def auth(token):
     return {"Authorization": f"Bearer {token}"}
 
 
+NODE_ID_A = "PVT_kwDOA1"
+NODE_ID_B = "PVT_kwDOB2"
+NODE_ID_C = "PVT_kwDOC3"
+
+
 # ---------------------------------------------------------------------------
-# 1. Member creates personal project → 201
+# 1. User creates project → 201
 # ---------------------------------------------------------------------------
 
 
-async def test_member_creates_personal_project(client, db_session):
-    member, tok = await make_user(db_session, "p01_member@t.com")
-    team = await make_team(db_session, "p01_Team")
-    await make_membership(db_session, member.id, team.id)
+async def test_create_project(client, db_session):
+    user, tok = await make_active_user(db_session, "p01_user@t.com")
 
     resp = await client.post(
         "/api/v1/projects",
-        json={"name": "p01_Project", "scope": "personal"},
+        json={
+            "name": "p01_Project",
+            "github_project_node_id": NODE_ID_A,
+            "github_project_number": 1,
+            "github_project_owner": "my-org",
+        },
         headers=auth(tok),
     )
     assert resp.status_code == 201
     data = resp.json()
     assert data["name"] == "p01_Project"
-    assert data["scope"] == "personal"
-    assert data["created_by"] == str(member.id)
+    assert data["github_project_node_id"] == NODE_ID_A
+    assert data["github_project_number"] == 1
+    assert data["github_project_owner"] == "my-org"
+    assert data["created_by"] == str(user.id)
 
 
 # ---------------------------------------------------------------------------
-# 2. Member creates team project → 201, team_id = member's team
+# 2. Duplicate node ID → 409
 # ---------------------------------------------------------------------------
 
 
-async def test_member_creates_team_project(client, db_session):
-    member, tok = await make_user(db_session, "p02_member@t.com")
-    team = await make_team(db_session, "p02_Team")
-    await make_membership(db_session, member.id, team.id)
+async def test_duplicate_node_id_returns_409(client, db_session):
+    user, tok = await make_active_user(db_session, "p02_user@t.com")
 
-    resp = await client.post(
-        "/api/v1/projects",
-        json={"name": "p02_Project", "scope": "team"},
-        headers=auth(tok),
-    )
-    assert resp.status_code == 201
-    data = resp.json()
-    assert data["scope"] == "team"
-    assert data["team_id"] == str(team.id)
-
-
-# ---------------------------------------------------------------------------
-# 3. Member tries cross_team → 403
-# ---------------------------------------------------------------------------
-
-
-async def test_member_cannot_create_cross_team_project(client, db_session):
-    member, tok = await make_user(db_session, "p03_member@t.com")
-    team = await make_team(db_session, "p03_Team")
-    await make_membership(db_session, member.id, team.id)
-
-    resp = await client.post(
-        "/api/v1/projects",
-        json={"name": "p03_Project", "scope": "cross_team"},
-        headers=auth(tok),
-    )
-    assert resp.status_code == 403
-
-
-# ---------------------------------------------------------------------------
-# 4. Leader creates cross_team → 201, team_id = None
-# ---------------------------------------------------------------------------
-
-
-async def test_leader_creates_cross_team_project(client, db_session):
-    leader, tok = await make_user(db_session, "p04_leader@t.com", is_leader=True)
-    team = await make_team(db_session, "p04_Team")
-    await make_membership(db_session, leader.id, team.id)
-
-    resp = await client.post(
-        "/api/v1/projects",
-        json={"name": "p04_Project", "scope": "cross_team"},
-        headers=auth(tok),
-    )
-    assert resp.status_code == 201
-    data = resp.json()
-    assert data["scope"] == "cross_team"
-    assert data["team_id"] is None
-
-
-# ---------------------------------------------------------------------------
-# 5. GET projects: member sees own personal + team + all cross_team
-# ---------------------------------------------------------------------------
-
-
-async def test_get_projects_visibility(client, db_session):
-    member, tok = await make_user(db_session, "p05_member@t.com")
-    other, other_tok = await make_user(db_session, "p05_other@t.com")
-    leader, leader_tok = await make_user(db_session, "p05_leader@t.com", is_leader=True)
-
-    team = await make_team(db_session, "p05_Team")
-    other_team = await make_team(db_session, "p05_OtherTeam")
-
-    await make_membership(db_session, member.id, team.id)
-    await make_membership(db_session, other.id, other_team.id)
-    await make_membership(db_session, leader.id, team.id)
-
-    # Create projects
     await client.post(
         "/api/v1/projects",
-        json={"name": "p05_Personal", "scope": "personal"},
+        json={"name": "p02_First", "github_project_node_id": NODE_ID_B},
         headers=auth(tok),
+    )
+    resp = await client.post(
+        "/api/v1/projects",
+        json={"name": "p02_Second", "github_project_node_id": NODE_ID_B},
+        headers=auth(tok),
+    )
+    assert resp.status_code == 409
+
+
+# ---------------------------------------------------------------------------
+# 3. GET /projects — creator sees own projects only
+# ---------------------------------------------------------------------------
+
+
+async def test_list_projects_creator_only(client, db_session):
+    owner, owner_tok = await make_active_user(db_session, "p03_owner@t.com")
+    other, other_tok = await make_active_user(db_session, "p03_other@t.com")
+
+    await client.post(
+        "/api/v1/projects",
+        json={"name": "p03_OwnerProj", "github_project_node_id": "p03_NODE_OWNER"},
+        headers=auth(owner_tok),
     )
     await client.post(
         "/api/v1/projects",
-        json={"name": "p05_Team", "scope": "team"},
-        headers=auth(tok),
-    )
-    await client.post(
-        "/api/v1/projects",
-        json={"name": "p05_OtherPersonal", "scope": "personal"},
+        json={"name": "p03_OtherProj", "github_project_node_id": "p03_NODE_OTHER"},
         headers=auth(other_tok),
     )
-    await client.post(
-        "/api/v1/projects",
-        json={"name": "p05_CrossTeam", "scope": "cross_team"},
-        headers=auth(leader_tok),
-    )
 
-    resp = await client.get("/api/v1/projects", headers=auth(tok))
+    resp = await client.get("/api/v1/projects", headers=auth(owner_tok))
     assert resp.status_code == 200
     names = {p["name"] for p in resp.json()}
-
-    assert "p05_Personal" in names  # own personal
-    assert "p05_Team" in names  # own team
-    assert "p05_CrossTeam" in names  # all cross_team
-    assert "p05_OtherPersonal" not in names  # other user's personal
+    assert "p03_OwnerProj" in names
+    assert "p03_OtherProj" not in names
 
 
 # ---------------------------------------------------------------------------
-# 6. Soft-delete project (is_active=False) → hidden from default list
+# 4. Admin sees all projects
+# ---------------------------------------------------------------------------
+
+
+async def test_admin_sees_all_projects(client, db_session):
+    user, user_tok = await make_active_user(db_session, "p04_user@t.com")
+    admin, admin_tok = await make_active_user(db_session, "p04_admin@t.com", is_admin=True)
+
+    await client.post(
+        "/api/v1/projects",
+        json={"name": "p04_UserProj", "github_project_node_id": "p04_NODE_USER"},
+        headers=auth(user_tok),
+    )
+
+    resp = await client.get("/api/v1/projects", headers=auth(admin_tok))
+    assert resp.status_code == 200
+    names = {p["name"] for p in resp.json()}
+    assert "p04_UserProj" in names
+
+
+# ---------------------------------------------------------------------------
+# 5. Soft-delete project → hidden from default list
 # ---------------------------------------------------------------------------
 
 
 async def test_soft_delete_project(client, db_session):
-    member, tok = await make_user(db_session, "p06_member@t.com")
-    team = await make_team(db_session, "p06_Team")
-    await make_membership(db_session, member.id, team.id)
+    user, tok = await make_active_user(db_session, "p05_user@t.com")
 
     create_resp = await client.post(
         "/api/v1/projects",
-        json={"name": "p06_Project", "scope": "personal"},
+        json={"name": "p05_Project", "github_project_node_id": "p05_NODE"},
         headers=auth(tok),
     )
     project_id = create_resp.json()["id"]
@@ -204,85 +178,20 @@ async def test_soft_delete_project(client, db_session):
 
     list_resp = await client.get("/api/v1/projects", headers=auth(tok))
     names = [p["name"] for p in list_resp.json()]
-    assert "p06_Project" not in names
+    assert "p05_Project" not in names
 
 
 # ---------------------------------------------------------------------------
-# 7. Promote team→cross_team by leader → scope=cross_team, notification row created
+# 6. GET /projects/{id} — owner can access
 # ---------------------------------------------------------------------------
 
 
-async def test_promote_project_by_leader(client, db_session):
-    member, member_tok = await make_user(db_session, "p07_member@t.com")
-    leader, leader_tok = await make_user(db_session, "p07_leader@t.com", is_leader=True)
-    team = await make_team(db_session, "p07_Team")
-    await make_membership(db_session, member.id, team.id)
-    await make_membership(db_session, leader.id, team.id)
+async def test_owner_gets_project_detail(client, db_session):
+    user, tok = await make_active_user(db_session, "p06_user@t.com")
 
     create_resp = await client.post(
         "/api/v1/projects",
-        json={"name": "p07_Project", "scope": "team"},
-        headers=auth(member_tok),
-    )
-    assert create_resp.status_code == 201
-    project_id = create_resp.json()["id"]
-
-    promote_resp = await client.post(
-        f"/api/v1/projects/{project_id}/promote", headers=auth(leader_tok)
-    )
-    assert promote_resp.status_code == 200
-    data = promote_resp.json()
-    assert data["scope"] == "cross_team"
-    assert data["team_id"] is None
-
-    # Verify notification row was created
-    notif_result = await db_session.execute(
-        select(Notification).where(
-            Notification.trigger_type == "project_promoted",
-            Notification.user_id == member.id,
-        )
-    )
-    notif = notif_result.scalar_one_or_none()
-    assert notif is not None
-    assert notif.data["project_id"] == project_id
-
-
-# ---------------------------------------------------------------------------
-# 8. Non-leader tries to promote → 403
-# ---------------------------------------------------------------------------
-
-
-async def test_non_leader_cannot_promote(client, db_session):
-    member, tok = await make_user(db_session, "p08_member@t.com")
-    team = await make_team(db_session, "p08_Team")
-    await make_membership(db_session, member.id, team.id)
-
-    create_resp = await client.post(
-        "/api/v1/projects",
-        json={"name": "p08_Project", "scope": "team"},
-        headers=auth(tok),
-    )
-    project_id = create_resp.json()["id"]
-
-    promote_resp = await client.post(
-        f"/api/v1/projects/{project_id}/promote", headers=auth(tok)
-    )
-    assert promote_resp.status_code == 403
-
-
-# ---------------------------------------------------------------------------
-# 9. GET /projects/{project_id} — detail endpoint
-# ---------------------------------------------------------------------------
-
-
-async def test_owner_gets_personal_project_detail(client, db_session):
-    member, tok = await make_user(db_session, "p09_member@t.com")
-    team = await make_team(db_session, "p09_Team")
-    await make_membership(db_session, member.id, team.id)
-
-    create_resp = await client.post(
-        "/api/v1/projects",
-        json={"name": "p09_Personal", "scope": "personal"},
+        json={"name": "p06_Project", "github_project_node_id": "p06_NODE"},
         headers=auth(tok),
     )
     project_id = create_resp.json()["id"]
@@ -290,69 +199,85 @@ async def test_owner_gets_personal_project_detail(client, db_session):
     resp = await client.get(f"/api/v1/projects/{project_id}", headers=auth(tok))
     assert resp.status_code == 200
     assert resp.json()["id"] == project_id
-    assert resp.json()["scope"] == "personal"
 
 
-async def test_member_gets_team_project_detail(client, db_session):
-    member, tok = await make_user(db_session, "p10_member@t.com")
-    team = await make_team(db_session, "p10_Team")
-    await make_membership(db_session, member.id, team.id)
-
-    create_resp = await client.post(
-        "/api/v1/projects",
-        json={"name": "p10_TeamProj", "scope": "team"},
-        headers=auth(tok),
-    )
-    project_id = create_resp.json()["id"]
-
-    resp = await client.get(f"/api/v1/projects/{project_id}", headers=auth(tok))
-    assert resp.status_code == 200
-    assert resp.json()["scope"] == "team"
+# ---------------------------------------------------------------------------
+# 7. Non-owner cannot access project detail → 403
+# ---------------------------------------------------------------------------
 
 
-async def test_any_user_gets_cross_team_project_detail(client, db_session):
-    leader, leader_tok = await make_user(db_session, "p11_leader@t.com", is_leader=True)
-    other, other_tok = await make_user(db_session, "p11_other@t.com")
-    team = await make_team(db_session, "p11_Team")
-    other_team = await make_team(db_session, "p11_OtherTeam")
-    await make_membership(db_session, leader.id, team.id)
-    await make_membership(db_session, other.id, other_team.id)
+async def test_non_owner_cannot_get_project_detail(client, db_session):
+    owner, owner_tok = await make_active_user(db_session, "p07_owner@t.com")
+    other, other_tok = await make_active_user(db_session, "p07_other@t.com")
 
     create_resp = await client.post(
         "/api/v1/projects",
-        json={"name": "p11_CrossTeam", "scope": "cross_team"},
-        headers=auth(leader_tok),
-    )
-    project_id = create_resp.json()["id"]
-
-    resp = await client.get(f"/api/v1/projects/{project_id}", headers=auth(other_tok))
-    assert resp.status_code == 200
-    assert resp.json()["scope"] == "cross_team"
-
-
-async def test_get_project_detail_not_found(client, db_session):
-    member, tok = await make_user(db_session, "p12_member@t.com")
-    team = await make_team(db_session, "p12_Team")
-    await make_membership(db_session, member.id, team.id)
-    import uuid
-
-    resp = await client.get(f"/api/v1/projects/{uuid.uuid4()}", headers=auth(tok))
-    assert resp.status_code == 404
-
-
-async def test_non_owner_cannot_get_personal_project_detail(client, db_session):
-    owner, owner_tok = await make_user(db_session, "p13_owner@t.com")
-    other, other_tok = await make_user(db_session, "p13_other@t.com")
-    team = await make_team(db_session, "p13_Team")
-    await make_membership(db_session, owner.id, team.id)
-    await make_membership(db_session, other.id, team.id)
-
-    create_resp = await client.post(
-        "/api/v1/projects",
-        json={"name": "p13_Personal", "scope": "personal"},
+        json={"name": "p07_Project", "github_project_node_id": "p07_NODE"},
         headers=auth(owner_tok),
     )
     project_id = create_resp.json()["id"]
 
     resp = await client.get(f"/api/v1/projects/{project_id}", headers=auth(other_tok))
+    assert resp.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# 8. GET /projects/{id} — not found → 404
+# ---------------------------------------------------------------------------
+
+
+async def test_get_project_not_found(client, db_session):
+    user, tok = await make_active_user(db_session, "p08_user@t.com")
+
+    resp = await client.get(f"/api/v1/projects/{uuid.uuid4()}", headers=auth(tok))
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# 9. PATCH — update github_project_number and github_project_owner
+# ---------------------------------------------------------------------------
+
+
+async def test_update_github_project_fields(client, db_session):
+    user, tok = await make_active_user(db_session, "p09_user@t.com")
+
+    create_resp = await client.post(
+        "/api/v1/projects",
+        json={"name": "p09_Project", "github_project_node_id": "p09_NODE"},
+        headers=auth(tok),
+    )
+    project_id = create_resp.json()["id"]
+
+    patch_resp = await client.patch(
+        f"/api/v1/projects/{project_id}",
+        json={"github_project_number": 42, "github_project_owner": "new-org"},
+        headers=auth(tok),
+    )
+    assert patch_resp.status_code == 200
+    data = patch_resp.json()
+    assert data["github_project_number"] == 42
+    assert data["github_project_owner"] == "new-org"
+
+
+# ---------------------------------------------------------------------------
+# 10. Non-owner cannot update project → 403
+# ---------------------------------------------------------------------------
+
+
+async def test_non_owner_cannot_update_project(client, db_session):
+    owner, owner_tok = await make_active_user(db_session, "p10_owner@t.com")
+    other, other_tok = await make_active_user(db_session, "p10_other@t.com")
+
+    create_resp = await client.post(
+        "/api/v1/projects",
+        json={"name": "p10_Project", "github_project_node_id": "p10_NODE"},
+        headers=auth(owner_tok),
+    )
+    project_id = create_resp.json()["id"]
+
+    resp = await client.patch(
+        f"/api/v1/projects/{project_id}",
+        json={"name": "Hacked"},
+        headers=auth(other_tok),
+    )
     assert resp.status_code == 403

--- a/backend/app/tests/test_projects.py
+++ b/backend/app/tests/test_projects.py
@@ -142,7 +142,9 @@ async def test_list_projects_creator_only(client, db_session):
 
 async def test_admin_sees_all_projects(client, db_session):
     user, user_tok = await make_active_user(db_session, "p04_user@t.com")
-    admin, admin_tok = await make_active_user(db_session, "p04_admin@t.com", is_admin=True)
+    admin, admin_tok = await make_active_user(
+        db_session, "p04_admin@t.com", is_admin=True
+    )
 
     await client.post(
         "/api/v1/projects",

--- a/backend/app/tests/test_tasks.py
+++ b/backend/app/tests/test_tasks.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 
 from app.core.security import create_access_token
 from app.db.models.category import Category
-from app.db.models.project import Project, ProjectScope
+from app.db.models.project import Project
 from app.db.models.team import Team, TeamMembership, TeamSettings
 from app.db.models.user import User
 
@@ -48,7 +48,9 @@ async def make_category(db, name="Cat"):
 
 
 async def make_project(db, created_by):
-    p = Project(name="Proj", scope=ProjectScope.personal, created_by=created_by)
+    p = Project(
+        name="Proj", github_project_node_id=f"PVT_{created_by}", created_by=created_by
+    )
     db.add(p)
     await db.commit()
     await db.refresh(p)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { TeamQuarterlyReportPage } from './pages/TeamQuarterlyReportPage';
 import { NotFoundPage } from './pages/NotFoundPage';
 import { CrossTeamSharingPage } from './pages/CrossTeamSharingPage';
 import { ProjectsPage } from './pages/ProjectsPage';
+import { ProjectDetailPage } from './pages/ProjectDetailPage';
 import { ProfileSettingsPage } from './pages/ProfileSettingsPage';
 
 function App() {
@@ -47,6 +48,7 @@ function App() {
           <Route path="team/unlock" element={<ProtectedRoute requireLeader><UnlockPage /></ProtectedRoute>} />
           <Route path="team/sharing" element={<ProtectedRoute requireLeader><CrossTeamSharingPage /></ProtectedRoute>} />
           <Route path="projects" element={<ProjectsPage />} />
+          <Route path="projects/:id" element={<ProjectDetailPage />} />
           <Route path="reports/weekly/:week_start?" element={<WeeklyReportPage />} />
           <Route path="reports/monthly/:ym?" element={<MonthlyReportPage />} />
           <Route path="reports/quarterly/:quarter?" element={<QuarterlyReportPage />} />

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -1,12 +1,30 @@
 import client from './client';
 import type { Project } from '../types/dailyRecord';
 
+export interface GitHubAvailableProject {
+  node_id: string;
+  number: number;
+  title: string;
+  owner_login: string;
+  url: string;
+}
+
 export async function getProjects(): Promise<Project[]> {
   const res = await client.get<Project[]>('/projects');
   return res.data;
 }
 
-export async function createProject(payload: { name: string; scope: 'personal' | 'team' | 'cross_team' }): Promise<Project> {
+export async function getAvailableGitHubProjects(): Promise<GitHubAvailableProject[]> {
+  const res = await client.get<GitHubAvailableProject[]>('/projects/github/available');
+  return res.data;
+}
+
+export async function createProject(payload: {
+  name: string;
+  github_project_node_id: string;
+  github_project_number?: number;
+  github_project_owner?: string;
+}): Promise<Project> {
   const res = await client.post<Project>('/projects', payload);
   return res.data;
 }

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -37,6 +37,7 @@ export interface UpdateTaskPayload {
 export async function getTasks(params?: {
   status?: string;
   assignee_id?: string;
+  project_id?: string;
 }): Promise<Task[]> {
   const res = await client.get<Task[]>('/tasks', { params });
   return res.data;

--- a/frontend/src/api/tasks.ts
+++ b/frontend/src/api/tasks.ts
@@ -10,6 +10,7 @@ export interface CreateTaskPayload {
   category_id: string;
   work_type_id: string;
   status: 'todo' | 'running' | 'done' | 'blocked';
+  github_status?: string | null;
   priority?: 'p0_critical' | 'p1_high' | 'p2_medium' | 'p3_low' | null;
   estimated_effort?: number | null;
   due_date?: string | null;
@@ -26,6 +27,7 @@ export interface UpdateTaskPayload {
   category_id?: string;
   work_type_id?: string | null;
   status?: 'todo' | 'running' | 'done' | 'blocked';
+  github_status?: string | null;
   priority?: 'p0_critical' | 'p1_high' | 'p2_medium' | 'p3_low' | null;
   estimated_effort?: number | null;
   due_date?: string | null;
@@ -77,6 +79,7 @@ export interface GithubAutofillResult {
   work_type_id: string | null;
   estimated_effort: number | null;
   status: 'todo' | 'done' | null;
+  github_status: string | null;
   insight: string | null;
 }
 

--- a/frontend/src/components/tasks/TaskCreateModal.tsx
+++ b/frontend/src/components/tasks/TaskCreateModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
-import { createProject } from '../../api/projects';
+import { createProject, getAvailableGitHubProjects } from '../../api/projects';
+import type { GitHubAvailableProject } from '../../api/projects';
 import { createTask, getWorkTypes, prefillFromGithubIssue } from '../../api/tasks';
 import type {
   Category,
@@ -51,8 +52,10 @@ export const TaskCreateModal = ({
   const [autofillError, setAutofillError] = useState<string | null>(null);
 
   const [showNewProject, setShowNewProject] = useState(false);
-  const [newProjectName, setNewProjectName] = useState('');
-  const [newProjectScope, setNewProjectScope] = useState<Project['scope']>('personal');
+  const [availableGHProjects, setAvailableGHProjects] = useState<GitHubAvailableProject[]>([]);
+  const [ghProjectsLoading, setGhProjectsLoading] = useState(false);
+  const [ghProjectsError, setGhProjectsError] = useState<string | null>(null);
+  const [selectedGHNodeId, setSelectedGHNodeId] = useState('');
   const [projectSaving, setProjectSaving] = useState(false);
   const [projectError, setProjectError] = useState('');
 
@@ -80,6 +83,9 @@ export const TaskCreateModal = ({
       setAutofillMsg(null);
       setAutofillError(null);
       setShowNewProject(false);
+      setAvailableGHProjects([]);
+      setGhProjectsError(null);
+      setSelectedGHNodeId('');
       setFormError(null);
     }
   }, [open]);
@@ -116,20 +122,38 @@ export const TaskCreateModal = ({
     }
   };
 
+  const openNewProjectPanel = () => {
+    setShowNewProject((v) => !v);
+    setProjectError('');
+    if (!showNewProject && availableGHProjects.length === 0) {
+      setGhProjectsLoading(true);
+      setGhProjectsError(null);
+      getAvailableGitHubProjects()
+        .then(setAvailableGHProjects)
+        .catch(() => setGhProjectsError('Could not load GitHub Projects. Make sure your GitHub account is linked.'))
+        .finally(() => setGhProjectsLoading(false));
+    }
+  };
+
   const submitNewProject = async () => {
-    const name = newProjectName.trim();
-    if (!name) { setProjectError('Name is required.'); return; }
+    if (!selectedGHNodeId) { setProjectError('Select a GitHub Project.'); return; }
+    const selected = availableGHProjects.find((p) => p.node_id === selectedGHNodeId);
     setProjectSaving(true);
     setProjectError('');
     try {
-      const created = await createProject({ name, scope: newProjectScope });
+      const created = await createProject({
+        name: selected?.title ?? selectedGHNodeId,
+        github_project_node_id: selectedGHNodeId,
+        github_project_number: selected?.number,
+        github_project_owner: selected?.owner_login,
+      });
       onProjectCreated(created);
       setProjectId(created.id);
       setShowNewProject(false);
-      setNewProjectName('');
-      setNewProjectScope('personal');
-    } catch {
-      setProjectError('Failed to create project. Please try again.');
+      setSelectedGHNodeId('');
+    } catch (err: unknown) {
+      const detail = (err as { response?: { data?: { detail?: string } } })?.response?.data?.detail;
+      setProjectError(detail ?? 'Failed to create project. Please try again.');
     } finally {
       setProjectSaving(false);
     }
@@ -288,12 +312,14 @@ export const TaskCreateModal = ({
             >
               <option value="">— select —</option>
               {projects.filter((p) => p.is_active).map((p) => (
-                <option key={p.id} value={p.id}>{p.name} ({p.scope})</option>
+                <option key={p.id} value={p.id}>
+                  {p.github_project_owner ? `${p.name} (${p.github_project_owner})` : p.name}
+                </option>
               ))}
             </select>
             <button
               type="button"
-              onClick={() => { setShowNewProject((v) => !v); setProjectError(''); }}
+              onClick={openNewProjectPanel}
               style={s.inlineBtn}
               title="Create a new project"
             >
@@ -302,40 +328,40 @@ export const TaskCreateModal = ({
           </div>
           {showNewProject && (
             <div style={s.inlineForm}>
-              <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
-                <input
-                  style={{ ...s.input, flex: 1, minWidth: '140px' }}
-                  placeholder="Project name"
-                  value={newProjectName}
-                  onChange={(e) => { setNewProjectName(e.target.value); setProjectError(''); }}
-                  onKeyDown={(e) => e.key === 'Enter' && submitNewProject()}
-                  autoFocus
-                />
-                <select
-                  style={s.select}
-                  value={newProjectScope}
-                  onChange={(e) => setNewProjectScope(e.target.value as Project['scope'])}
-                >
-                  <option value="personal">Personal</option>
-                  <option value="team">Team</option>
-                  <option value="cross_team">Cross-team</option>
-                </select>
-                <button
-                  type="button"
-                  onClick={submitNewProject}
-                  disabled={projectSaving}
-                  style={s.createBtn}
-                >
-                  {projectSaving ? 'Creating…' : 'Create'}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => { setShowNewProject(false); setProjectError(''); }}
-                  style={s.cancelBtn}
-                >
-                  Cancel
-                </button>
-              </div>
+              {ghProjectsLoading && <p style={{ margin: 0, fontSize: '0.8rem' }}>Loading GitHub Projects…</p>}
+              {ghProjectsError && <p style={{ margin: 0, fontSize: '0.8rem', color: 'var(--error)' }}>{ghProjectsError}</p>}
+              {!ghProjectsLoading && !ghProjectsError && (
+                <div style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', flexWrap: 'wrap' }}>
+                  <select
+                    style={{ ...s.select, flex: 1 }}
+                    value={selectedGHNodeId}
+                    onChange={(e) => { setSelectedGHNodeId(e.target.value); setProjectError(''); }}
+                    autoFocus
+                  >
+                    <option value="">— select a GitHub Project —</option>
+                    {availableGHProjects.map((p) => (
+                      <option key={p.node_id} value={p.node_id}>
+                        {p.title} ({p.owner_login})
+                      </option>
+                    ))}
+                  </select>
+                  <button
+                    type="button"
+                    onClick={submitNewProject}
+                    disabled={projectSaving || !selectedGHNodeId}
+                    style={s.createBtn}
+                  >
+                    {projectSaving ? 'Adding…' : 'Add'}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setShowNewProject(false); setProjectError(''); }}
+                    style={s.cancelBtn}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
               {projectError && <p style={{ color: 'var(--error)', fontSize: '0.75rem', margin: '0.3rem 0 0' }}>{projectError}</p>}
             </div>
           )}

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -118,7 +118,7 @@ export const ProjectDetailPage = () => {
         <ul style={listStyle}>
           {filteredTasks.map((task) => (
             <li key={task.id} style={taskRowStyle}>
-              {/* Status badge */}
+              {/* Internal status badge */}
               <span
                 style={{
                   ...statusBadgeStyle,
@@ -127,6 +127,13 @@ export const ProjectDetailPage = () => {
               >
                 {task.status}
               </span>
+
+              {/* GitHub board column badge (when present) */}
+              {task.github_status && (
+                <span style={githubStatusBadgeStyle} title="GitHub Project board column">
+                  {task.github_status}
+                </span>
+              )}
 
               {/* Title + optional GitHub link */}
               <span style={{ flex: 1 }}>
@@ -259,6 +266,17 @@ const statusBadgeStyle: React.CSSProperties = {
   fontWeight: 700,
   color: '#fff',
   textTransform: 'capitalize',
+  whiteSpace: 'nowrap',
+};
+
+const githubStatusBadgeStyle: React.CSSProperties = {
+  padding: '0.15rem 0.5rem',
+  borderRadius: '4px',
+  fontSize: '0.7rem',
+  fontWeight: 500,
+  color: 'var(--text-secondary)',
+  background: 'var(--bg-tertiary)',
+  border: '1px solid var(--border)',
   whiteSpace: 'nowrap',
 };
 

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -1,0 +1,293 @@
+import { useEffect, useState } from 'react';
+import { useParams, Link } from 'react-router-dom';
+import { getProjects } from '../api/projects';
+import { getTasks, getWorkTypes } from '../api/tasks';
+import type { Project, Task, WorkType } from '../types/dailyRecord';
+
+type StatusFilter = 'todo' | 'running' | 'done' | 'blocked' | 'all';
+
+const STATUS_TABS: { value: StatusFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'todo', label: 'Todo' },
+  { value: 'running', label: 'Running' },
+  { value: 'done', label: 'Done' },
+  { value: 'blocked', label: 'Blocked' },
+];
+
+const STATUS_COLORS: Record<string, string> = {
+  todo: '#868e96',
+  running: '#1971c2',
+  done: '#2f9e44',
+  blocked: '#c92a2a',
+};
+
+export const ProjectDetailPage = () => {
+  const { id } = useParams<{ id: string }>();
+
+  const [project, setProject] = useState<Project | null>(null);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [workTypes, setWorkTypes] = useState<WorkType[]>([]);
+  const [filter, setFilter] = useState<StatusFilter>('todo');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    let cancelled = false;
+    Promise.all([getProjects(), getTasks({ project_id: id }), getWorkTypes()])
+      .then(([projects, taskList, wtList]) => {
+        if (cancelled) return;
+        const found = projects.find((p) => p.id === id) ?? null;
+        setProject(found);
+        setTasks(taskList);
+        setWorkTypes(wtList);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setError('Failed to load project details.');
+          setLoading(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [id]);
+
+  if (loading) return <p style={{ padding: '1rem' }}>Loading…</p>;
+  if (error) return <p style={{ padding: '1rem', color: 'var(--error)' }}>{error}</p>;
+  if (!project) return <p style={{ padding: '1rem', color: 'var(--error)' }}>Project not found.</p>;
+
+  const workTypeMap = new Map(workTypes.map((wt) => [wt.id, wt.name]));
+
+  const filteredTasks =
+    filter === 'all' ? tasks : tasks.filter((t) => t.status === filter);
+
+  const activeTasks = tasks.filter((t) => t.status === 'todo' || t.status === 'running');
+  const defaultFilterCount = activeTasks.length;
+
+  return (
+    <div style={{ maxWidth: '900px', margin: '0 auto' }}>
+      {/* Back link */}
+      <Link to="/projects" style={backLinkStyle}>
+        ← Projects
+      </Link>
+
+      {/* Project header */}
+      <div style={headerStyle}>
+        <div>
+          <h2 style={{ margin: '0 0 0.25rem' }}>{project.name}</h2>
+          {project.github_project_owner && (
+            <a
+              href={`https://github.com/${project.github_project_owner}`}
+              target="_blank"
+              rel="noreferrer"
+              style={ownerLinkStyle}
+            >
+              @{project.github_project_owner}
+            </a>
+          )}
+        </div>
+        <span style={activeBadgeStyle}>{defaultFilterCount} active</span>
+      </div>
+
+      {/* Status filter tabs */}
+      <div style={tabsContainerStyle}>
+        {STATUS_TABS.map((tab) => {
+          const count = tab.value === 'all' ? tasks.length : tasks.filter((t) => t.status === tab.value).length;
+          return (
+            <button
+              key={tab.value}
+              onClick={() => setFilter(tab.value)}
+              style={{
+                ...tabBtnStyle,
+                ...(filter === tab.value ? activeTabStyle : {}),
+              }}
+            >
+              {tab.label}
+              <span style={tabCountStyle}>{count}</span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Task list */}
+      {filteredTasks.length === 0 ? (
+        <p style={emptyMsgStyle}>No tasks match this filter.</p>
+      ) : (
+        <ul style={listStyle}>
+          {filteredTasks.map((task) => (
+            <li key={task.id} style={taskRowStyle}>
+              {/* Status badge */}
+              <span
+                style={{
+                  ...statusBadgeStyle,
+                  background: STATUS_COLORS[task.status] ?? '#868e96',
+                }}
+              >
+                {task.status}
+              </span>
+
+              {/* Title + optional GitHub link */}
+              <span style={{ flex: 1 }}>
+                {task.title}
+                {task.github_issue_url && (
+                  <a
+                    href={task.github_issue_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    style={ghLinkStyle}
+                    title="Open GitHub Issue"
+                  >
+                    ↗
+                  </a>
+                )}
+              </span>
+
+              {/* Work type */}
+              <span style={metaChipStyle}>
+                {task.work_type_id ? (workTypeMap.get(task.work_type_id) ?? '—') : '—'}
+              </span>
+
+              {/* Effort */}
+              <span style={effortBadgeStyle}>
+                {task.estimated_effort != null ? `${task.estimated_effort} pts` : '—'}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+const backLinkStyle: React.CSSProperties = {
+  display: 'inline-block',
+  marginBottom: '1rem',
+  color: 'var(--text-secondary)',
+  fontSize: '0.85rem',
+  textDecoration: 'none',
+};
+
+const headerStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'flex-start',
+  justifyContent: 'space-between',
+  marginBottom: '1.25rem',
+  padding: '1rem',
+  background: 'var(--bg)',
+  border: '1px solid var(--border)',
+  borderRadius: '8px',
+};
+
+const ownerLinkStyle: React.CSSProperties = {
+  fontSize: '0.82rem',
+  color: 'var(--text-secondary)',
+  textDecoration: 'none',
+};
+
+const activeBadgeStyle: React.CSSProperties = {
+  padding: '0.25rem 0.75rem',
+  borderRadius: '999px',
+  background: 'var(--bg-tertiary)',
+  border: '1px solid var(--border)',
+  fontSize: '0.8rem',
+  color: 'var(--text-secondary)',
+  whiteSpace: 'nowrap',
+};
+
+const tabsContainerStyle: React.CSSProperties = {
+  display: 'flex',
+  gap: '0.25rem',
+  marginBottom: '0.75rem',
+  flexWrap: 'wrap',
+};
+
+const tabBtnStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.35rem',
+  padding: '0.35rem 0.75rem',
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: 'var(--border)',
+  borderRadius: '4px',
+  background: 'var(--bg)',
+  cursor: 'pointer',
+  fontSize: '0.85rem',
+  color: 'var(--text-secondary)',
+};
+
+const activeTabStyle: React.CSSProperties = {
+  background: 'var(--accent)',
+  color: '#fff',
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: 'var(--accent)',
+};
+
+const tabCountStyle: React.CSSProperties = {
+  fontSize: '0.75rem',
+  opacity: 0.8,
+};
+
+const listStyle: React.CSSProperties = {
+  margin: 0,
+  padding: 0,
+  listStyle: 'none',
+  border: '1px solid var(--border)',
+  borderRadius: '8px',
+  overflow: 'hidden',
+};
+
+const taskRowStyle: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '0.75rem',
+  padding: '0.6rem 1rem',
+  borderBottom: '1px solid var(--border-subtle)',
+  background: 'var(--bg)',
+};
+
+const statusBadgeStyle: React.CSSProperties = {
+  padding: '0.15rem 0.5rem',
+  borderRadius: '4px',
+  fontSize: '0.7rem',
+  fontWeight: 700,
+  color: '#fff',
+  textTransform: 'capitalize',
+  whiteSpace: 'nowrap',
+};
+
+const metaChipStyle: React.CSSProperties = {
+  fontSize: '0.78rem',
+  color: 'var(--text-secondary)',
+  whiteSpace: 'nowrap',
+};
+
+const effortBadgeStyle: React.CSSProperties = {
+  padding: '0.1rem 0.45rem',
+  borderRadius: '4px',
+  background: 'var(--bg-tertiary)',
+  border: '1px solid var(--border)',
+  fontSize: '0.75rem',
+  fontWeight: 600,
+  whiteSpace: 'nowrap',
+};
+
+const emptyMsgStyle: React.CSSProperties = {
+  padding: '2rem',
+  textAlign: 'center',
+  color: 'var(--text-secondary)',
+  fontSize: '0.9rem',
+};
+
+const ghLinkStyle: React.CSSProperties = {
+  marginLeft: '0.35rem',
+  fontSize: '0.75rem',
+  color: 'var(--text-secondary)',
+  textDecoration: 'none',
+};

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -27,7 +27,7 @@ export const ProjectDetailPage = () => {
   const [project, setProject] = useState<Project | null>(null);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [workTypes, setWorkTypes] = useState<WorkType[]>([]);
-  const [filter, setFilter] = useState<StatusFilter>('todo');
+  const [filter, setFilter] = useState<StatusFilter>('all');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -45,7 +45,9 @@ export const ProjectsPage = () => {
         <ul style={listStyle}>
           {active.map((p) => (
             <li key={p.id} style={itemStyle}>
-              <span style={scopeBadge(p.scope)}>{p.scope}</span>
+              {p.github_project_owner && (
+                <span style={ownerBadge}>@{p.github_project_owner}</span>
+              )}
               <input
                 style={inputStyle}
                 value={editNames[p.id] ?? p.name}
@@ -67,7 +69,9 @@ export const ProjectsPage = () => {
           <ul style={listStyle}>
             {inactive.map((p) => (
               <li key={p.id} style={{ ...itemStyle, opacity: 0.5 }}>
-                <span style={scopeBadge(p.scope)}>{p.scope}</span>
+                {p.github_project_owner && (
+                  <span style={ownerBadge}>@{p.github_project_owner}</span>
+                )}
                 <span style={{ flex: 1 }}>{p.name}</span>
                 <button style={tinyBtn} onClick={() => toggleActive(p)}>Reactivate</button>
               </li>
@@ -99,6 +103,15 @@ const itemStyle: React.CSSProperties = {
   borderBottom: '1px solid var(--border-subtle)',
 };
 const emptyMsg: React.CSSProperties = { margin: 0, fontSize: '0.85rem', color: 'var(--text-secondary)' };
+const ownerBadge: React.CSSProperties = {
+  padding: '0.1rem 0.4rem',
+  borderRadius: '4px',
+  fontSize: '0.7rem',
+  fontWeight: 600,
+  background: '#e9ecef',
+  color: '#495057',
+  whiteSpace: 'nowrap',
+};
 const inputStyle: React.CSSProperties = {
   flex: 1,
   border: '1px solid var(--border)',
@@ -120,20 +133,3 @@ const dangerBtn: React.CSSProperties = {
   color: 'var(--error)',
   borderColor: 'var(--error)',
 };
-
-function scopeBadge(scope: Project['scope']): React.CSSProperties {
-  const colors: Record<Project['scope'], string> = {
-    personal: '#6c757d',
-    team: '#0d6efd',
-    cross_team: '#198754',
-  };
-  return {
-    fontSize: '0.65rem',
-    padding: '0.1rem 0.35rem',
-    borderRadius: '3px',
-    background: colors[scope],
-    color: '#fff',
-    whiteSpace: 'nowrap',
-    fontWeight: 600,
-  };
-}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { AxiosError } from 'axios';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { getProjects, updateProject, getAvailableGitHubProjects, createProject } from '../api/projects';
 import type { GitHubAvailableProject } from '../api/projects';
 import type { Project } from '../types/dailyRecord';
@@ -159,6 +159,7 @@ export const ProjectsPage = () => {
                 }
                 onKeyDown={(e) => e.key === 'Enter' && rename(p)}
               />
+              <Link to={`/projects/${p.id}`} style={tinyBtn as React.CSSProperties}>View</Link>
               <button style={tinyBtn} onClick={() => rename(p)}>Rename</button>
               <button style={dangerBtn} onClick={() => toggleActive(p)}>Deactivate</button>
             </li>
@@ -176,6 +177,7 @@ export const ProjectsPage = () => {
                   <span style={ownerBadge}>@{p.github_project_owner}</span>
                 )}
                 <span style={{ flex: 1 }}>{p.name}</span>
+                <Link to={`/projects/${p.id}`} style={tinyBtn as React.CSSProperties}>View</Link>
                 <button style={tinyBtn} onClick={() => toggleActive(p)}>Reactivate</button>
               </li>
             ))}

--- a/frontend/src/pages/ProjectsPage.tsx
+++ b/frontend/src/pages/ProjectsPage.tsx
@@ -1,20 +1,38 @@
-import { useEffect, useState } from 'react';
-import { getProjects, updateProject } from '../api/projects';
+import { useCallback, useEffect, useState } from 'react';
+import { AxiosError } from 'axios';
+import { useNavigate } from 'react-router-dom';
+import { getProjects, updateProject, getAvailableGitHubProjects, createProject } from '../api/projects';
+import type { GitHubAvailableProject } from '../api/projects';
 import type { Project } from '../types/dailyRecord';
+import { useAuthStore } from '../stores/authStore';
 
 export const ProjectsPage = () => {
+  const user = useAuthStore((s) => s.user);
+  const navigate = useNavigate();
+
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
   const [editNames, setEditNames] = useState<Record<string, string>>({});
   const [error, setError] = useState<string | null>(null);
 
-  const reload = () =>
+  // Link Project flow
+  const [linkOpen, setLinkOpen] = useState(false);
+  const [available, setAvailable] = useState<GitHubAvailableProject[]>([]);
+  const [linkLoading, setLinkLoading] = useState(false);
+  const [linkError, setLinkError] = useState<string | null>(null);
+
+  const reload = useCallback(() => {
     getProjects()
       .then(setProjects)
       .catch(() => setError('Failed to load projects'))
       .finally(() => setLoading(false));
+  }, []);
 
-  useEffect(() => { reload(); }, []);
+  useEffect(() => {
+    if (user?.github_linked) {
+      reload();
+    }
+  }, [user?.github_linked, reload]);
 
   const rename = async (project: Project) => {
     const name = editNames[project.id]?.trim();
@@ -29,6 +47,65 @@ export const ProjectsPage = () => {
     reload();
   };
 
+  const openLinkPanel = async () => {
+    setLinkOpen(true);
+    setLinkError(null);
+    setLinkLoading(true);
+    try {
+      const results = await getAvailableGitHubProjects();
+      setAvailable(results);
+    } catch (err) {
+      const detail =
+        err instanceof AxiosError
+          ? (err.response?.data as { detail?: string } | undefined)?.detail
+          : undefined;
+      setLinkError(detail ?? 'Failed to load GitHub Projects.');
+    } finally {
+      setLinkLoading(false);
+    }
+  };
+
+  const closeLinkPanel = () => {
+    setLinkOpen(false);
+    setAvailable([]);
+    setLinkError(null);
+  };
+
+  const selectProject = async (proj: GitHubAvailableProject) => {
+    setLinkError(null);
+    try {
+      await createProject({
+        name: proj.title,
+        github_project_node_id: proj.node_id,
+        github_project_number: proj.number,
+        github_project_owner: proj.owner_login,
+      });
+      closeLinkPanel();
+      reload();
+    } catch (err) {
+      const detail =
+        err instanceof AxiosError
+          ? (err.response?.data as { detail?: string } | undefined)?.detail
+          : undefined;
+      setLinkError(detail ?? 'Failed to link project. Please try again.');
+    }
+  };
+
+  // GitHub connection gate — skip all fetches when not linked
+  if (!user?.github_linked) {
+    return (
+      <div style={{ maxWidth: '800px', margin: '0 auto', textAlign: 'center', paddingTop: '4rem' }}>
+        <h2 style={{ marginBottom: '1rem' }}>Projects</h2>
+        <p style={{ color: 'var(--text-secondary)', marginBottom: '1.5rem' }}>
+          Connect your GitHub account to link and manage GitHub Projects.
+        </p>
+        <button style={primaryBtn} onClick={() => navigate('/settings/profile')}>
+          Connect GitHub
+        </button>
+      </div>
+    );
+  }
+
   if (loading) return <p>Loading projects…</p>;
   if (error) return <p style={{ color: 'var(--error)' }}>{error}</p>;
 
@@ -37,7 +114,33 @@ export const ProjectsPage = () => {
 
   return (
     <div style={{ maxWidth: '800px', margin: '0 auto' }}>
-      <h2 style={{ marginBottom: '1rem' }}>Projects</h2>
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '1rem' }}>
+        <h2 style={{ margin: 0 }}>Projects</h2>
+        <button style={primaryBtn} onClick={openLinkPanel}>Link Project</button>
+      </div>
+
+      {linkOpen && (
+        <section style={{ ...sectionStyle, marginBottom: '1rem' }}>
+          <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: '0.75rem' }}>
+            <h3 style={{ ...sectionTitle, margin: 0 }}>Select a GitHub Project</h3>
+            <button style={tinyBtn} onClick={closeLinkPanel}>Cancel</button>
+          </div>
+          {linkLoading && <p style={{ margin: 0 }}>Loading GitHub Projects…</p>}
+          {linkError && <p style={{ color: 'var(--error)', margin: '0 0 0.5rem' }}>{linkError}</p>}
+          {!linkLoading && available.length === 0 && !linkError && (
+            <p style={emptyMsg}>No GitHub Projects found.</p>
+          )}
+          <ul style={listStyle}>
+            {available.map((proj) => (
+              <li key={proj.node_id} style={itemStyle}>
+                <span style={ownerBadge}>@{proj.owner_login}</span>
+                <span style={{ flex: 1 }}>{proj.title}</span>
+                <button style={tinyBtn} onClick={() => selectProject(proj)}>Select</button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
       <section style={sectionStyle}>
         <h3 style={sectionTitle}>Active ({active.length})</h3>
@@ -132,4 +235,13 @@ const dangerBtn: React.CSSProperties = {
   ...tinyBtn,
   color: 'var(--error)',
   borderColor: 'var(--error)',
+};
+const primaryBtn: React.CSSProperties = {
+  padding: '0.4rem 1rem',
+  background: 'var(--accent)',
+  color: '#fff',
+  border: 'none',
+  borderRadius: '4px',
+  cursor: 'pointer',
+  fontWeight: 600,
 };

--- a/frontend/src/types/dailyRecord.ts
+++ b/frontend/src/types/dailyRecord.ts
@@ -29,9 +29,12 @@ export interface BlockerType {
 export interface Project {
   id: string;
   name: string;
-  scope: 'personal' | 'team' | 'cross_team';
-  github_repo: string | null;
+  github_project_node_id: string;
+  github_project_number: number | null;
+  github_project_owner: string | null;
+  created_by: string;
   is_active: boolean;
+  created_at: string;
 }
 
 export interface SelfAssessmentTagRef {

--- a/frontend/src/types/dailyRecord.ts
+++ b/frontend/src/types/dailyRecord.ts
@@ -60,6 +60,7 @@ export interface Task {
   category_id: string;
   work_type_id: string | null;
   status: 'todo' | 'running' | 'done' | 'blocked';
+  github_status: string | null; // raw GitHub Project board column, e.g. "In Progress"
   priority: 'p0_critical' | 'p1_high' | 'p2_medium' | 'p3_low' | null;
   estimated_effort: number | null;
   due_date: string | null;


### PR DESCRIPTION
## What changed and why

Implements the full GitHub Projects integration as specified in #75. The `Project` model has been migrated to a GitHub-linked schema (dropping `scope`, `team_id`, `github_repo`; adding `github_project_node_id`, `github_project_number`, `github_project_owner`). A new `GET /projects/github/available` endpoint fetches available GitHub Projects via GraphQL. The `POST /projects` endpoint now accepts a `github_project_node_id` snapshot. The `promote` endpoint has been removed. On the frontend, `ProjectsPage` gates on GitHub connection status, exposes a "Link Project" flow, and a new `ProjectDetailPage` shows a filterable flat task list. `Task.github_status` field added for GitHub-side status tracking.

Closes #75
Closes #77
Closes #79
Closes #81
Closes #83
Closes #85
Closes #87

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor / tech debt
- [ ] Documentation
- [ ] CI/CD / infra
- [ ] Dependency upgrade

## Component(s) affected

- [x] backend
- [x] frontend
- [x] database schema / migration
- [ ] auth
- [ ] notifications / email
- [ ] LLM integration

## Testing done

- New `github_projects.py` service and updated project/task API endpoints covered by updated `test_projects.py` (381-line test file, heavily revised).
- [x] Existing tests pass (`uv run pytest` / `yarn lint && tsc --noEmit`)
- [x] New tests added (if applicable)
- [x] Manually tested locally

## Invariants checklist

- [ ] Edit window lock logic untouched or correctly updated — **N/A** (no edit window code touched)
- [ ] Private fields (`day_load`, `blocker_text`) stripped for non-owners/non-leaders — **N/A** (no daily record fields touched; project visibility enforced via `created_by` check)
- [ ] WebSocket visibility uses the same filter as REST — **N/A** (no WebSocket changes)
- [ ] `carried_from_id` is immutable after creation (not set or mutated here) — **N/A** (task carry-forward not touched)
- [ ] Exactly one `is_primary=true` tag per TaskEntry enforced (if task entry code touched) — **N/A** (no tag logic touched)
- [x] Soft-delete pattern used (no hard-delete on controlled lists) — **N/A** (Project is not a controlled list; migration uses wipe strategy agreed in issue)
- [ ] LLM user content injected in `<user_data>` delimiters (if LLM code touched) — **N/A** (no LLM code touched)
- [x] N/A — none of the critical invariants apply to this change

## Screenshots (UI changes only)

<!-- ProjectsPage and ProjectDetailPage were updated/added — attach before/after screenshots if available. -->
